### PR TITLE
Simplify and unify the frontmatter title and description

### DIFF
--- a/content/pages/en/about.mdx
+++ b/content/pages/en/about.mdx
@@ -1,7 +1,5 @@
 ---
-title: "About Open Terms Archive"
-description: "Free and open source software aiming at becoming a digital common."
-hero.title: "About"
+hero.title: "About Open Terms Archive"
 hero.subtitle: "Open Terms Archive is free and open source software aiming at becoming a digital common."
 ---
 

--- a/content/pages/en/case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer.mdx
+++ b/content/pages/en/case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer.mdx
@@ -1,5 +1,5 @@
 ---
-description: "The impact of the Covid-19 pandemic can be read right into Alibaba's terms of service: since May 6, 2020, the marketplace specified epidemics as cases of force majeure in which it is not responsible for order delays or failures."
+html_description: "The impact of the Covid-19 pandemic can be read right into Alibaba's terms of service: since May 6, 2020, the marketplace specified epidemics as cases of force majeure in which it is not responsible for order delays or failures."
 title: "Alibaba adds disease outbreaks to its disclaimer"
 service: "Alibaba"
 terms_types: ["Terms of use"]

--- a/content/pages/en/case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.mdx
+++ b/content/pages/en/case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Facebook has added a ban to its platform manipulation prevention rules."
+html_description: "Facebook has added a ban to its platform manipulation prevention rules."
 title: "Facebook bans States from denying the use of violence in an invasion"
 service: "Facebook"
 terms_types: ["Community Guidelines - Platform Manipulation"]

--- a/content/pages/en/case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.mdx
+++ b/content/pages/en/case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.mdx
@@ -1,5 +1,5 @@
 ---
-description: "In November 2021, Instagram made several updates to its community rules, its terms of use and its privacy policy."
+html_description: "In November 2021, Instagram made several updates to its community rules, its terms of use and its privacy policy."
 title: "Instagram blocks data retrieval and clarifies what information it retrieves"
 service: "Instagram"
 terms_types: ["Community Guidelines","Terms of use","Privacy Policy"]

--- a/content/pages/en/case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.mdx
+++ b/content/pages/en/case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Pinterest has removed a lengthy explanation of its data processing arrangements, which it said it was carrying out under the Privacy Shield then in place between the European Union and the United States."
+html_description: "Pinterest has removed a lengthy explanation of its data processing arrangements, which it said it was carrying out under the Privacy Shield then in place between the European Union and the United States."
 title: "Pinterest removes Privacy Shield notice without updating its modification date"
 service: "Pinterest"
 terms_types: ["Privacy Policy"]

--- a/content/pages/en/case-studies/protonmail-clarifies-its-privacy-policies.mdx
+++ b/content/pages/en/case-studies/protonmail-clarifies-its-privacy-policies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "On September 6, 2021, ProtonMail amended its privacy policies to clarify the effects of Swiss laws on handling user data."
+html_description: "On September 6, 2021, ProtonMail amended its privacy policies to clarify the effects of Swiss laws on handling user data."
 title: "Protonmail clarifies its privacy policies"
 service: "Protonmail"
 terms_types: ["Privacy Policy"]

--- a/content/pages/en/case-studies/qwant-details-data-shared-with-microsoft.mdx
+++ b/content/pages/en/case-studies/qwant-details-data-shared-with-microsoft.mdx
@@ -1,5 +1,5 @@
 ---
-description: "On November 2, 2021, Qwant specified in its privacy policy the type of data it passes on to its partner Microsoft “for the security and reliability of its services.”"
+html_description: "On November 2, 2021, Qwant specified in its privacy policy the type of data it passes on to its partner Microsoft “for the security and reliability of its services.”"
 title: "Qwant details data shared with Microsoft"
 service: "Qwant"
 terms_types: ["Privacy Policy"]

--- a/content/pages/en/case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.mdx
+++ b/content/pages/en/case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Twitter added a new condition to the issuance of a notice of dispute."
+html_description: "Twitter added a new condition to the issuance of a notice of dispute."
 title: "Twitter adds form and statement of jurisdictional consent to its copyright claims process"
 service: "Twitter"
 terms_types: ["Copyright Claims Policy"]

--- a/content/pages/en/case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.mdx
+++ b/content/pages/en/case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Twitter clarifies that content suspension for copyright infringement only happens if the violation of its Copyright Policy is repeated."
+html_description: "Twitter clarifies that content suspension for copyright infringement only happens if the violation of its Copyright Policy is repeated."
 title: "Twitter clarifies its content suspensions rules and allows appeal"
 service: "Twitter"
 terms_types: ["Copyright Claims Policy"]

--- a/content/pages/en/case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published.mdx
+++ b/content/pages/en/case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published.mdx
@@ -1,5 +1,5 @@
 ---
-description: "YouTube forbids the disclosure of another person’s “personal” data, and not only one’s “confidential” data."
+html_description: "YouTube forbids the disclosure of another person’s “personal” data, and not only one’s “confidential” data."
 title: "YouTube adds health data to the information prohibited from being published"
 service: "YouTube"
 terms_types: ["Community Guidelines - Harassment"]

--- a/content/pages/en/case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals.mdx
+++ b/content/pages/en/case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals.mdx
@@ -1,5 +1,5 @@
 ---
-description: "YouTube changed the presentation of its YouTube Trusted Flagger program."
+html_description: "YouTube changed the presentation of its YouTube Trusted Flagger program."
 title: "YouTube closes its fast-track content flagging program to individuals"
 service: "YouTube"
 terms_types: ["Community Guidelines"]

--- a/content/pages/en/subscribe/confirm.mdx
+++ b/content/pages/en/subscribe/confirm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Confirm your subscription"
+html_title: "Confirm your subscription"
 ---
 
 # Almost done!

--- a/content/pages/en/subscribe/done.mdx
+++ b/content/pages/en/subscribe/done.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Thanks for subscribing!"
+html_title: "Thanks for subscribing!"
 ---
 # You are now subscribed!
 

--- a/content/pages/en/subscribe/french-elections.mdx
+++ b/content/pages/en/subscribe/french-elections.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Subscribe to French Elections Memos"
+html_title: "Subscribe to French Elections Memos"
 ---
 # French Elections Memos
 

--- a/content/pages/fr/about.mdx
+++ b/content/pages/fr/about.mdx
@@ -1,7 +1,5 @@
 ---
-title: "À propos d'Open Terms Archive"
-description: "Logiciel libre et ouvert visant à devenir un commun numérique."
-hero.title: "À propos"
+hero.title: "À propos d'Open Terms Archive"
 hero.subtitle: "Open Terms Archive est un logiciel libre et ouvert visant à devenir un commun numérique."
 permalink: "/a-propos"
 ---

--- a/content/pages/fr/case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer.mdx
+++ b/content/pages/fr/case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer.mdx
@@ -1,5 +1,5 @@
 ---
-description: "L’épidémie de Covid se lit jusque dans les conditions d’utilisation d’Alibaba : depuis le 6 mai 2020, la place de marché précise dans les cas de force majeure dans lesquels elle n’est pas responsable des retards ou des échecs de commande."
+html_description: "L’épidémie de Covid se lit jusque dans les conditions d’utilisation d’Alibaba : depuis le 6 mai 2020, la place de marché précise dans les cas de force majeure dans lesquels elle n’est pas responsable des retards ou des échecs de commande."
 title: "Alibaba ajoute les épidémies à ses clauses d'exclusion de responsabilité"
 service: "Alibaba"
 terms_types: ["Terms of use"]

--- a/content/pages/fr/case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.mdx
+++ b/content/pages/fr/case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Facebook a ajouté une interdiction à ses règles de prévention de manipulation de sa plateforme."
+html_description: "Facebook a ajouté une interdiction à ses règles de prévention de manipulation de sa plateforme."
 title: "Facebook interdit aux États de nier l’usage de la force lors d’une invasion"
 service: "Facebook"
 terms_types: ["Community Guidelines - Platform Manipulation"]

--- a/content/pages/fr/case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.mdx
+++ b/content/pages/fr/case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.mdx
@@ -1,5 +1,5 @@
 ---
-description: "En novembre 2021, Instagram a procédé à plusieurs mises à jour de ses règles de communauté, de ses conditions d’utilisation et de sa politique de vie privée."
+html_description: "En novembre 2021, Instagram a procédé à plusieurs mises à jour de ses règles de communauté, de ses conditions d’utilisation et de sa politique de vie privée."
 title: "Instagram bloque la récupération de données et précise les informations qu’elle récupère"
 service: "Instagram"
 terms_types: ["Community Guidelines","Terms of use","Privacy Policy"]

--- a/content/pages/fr/case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.mdx
+++ b/content/pages/fr/case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Pinterest a supprimé une longue explication de ses modalités de traitement des données, qu’elle indiquait réaliser en vertu du Privacy Shield alors en place entre l’Union Européenne aux États-Unis."
+html_description: "Pinterest a supprimé une longue explication de ses modalités de traitement des données, qu’elle indiquait réaliser en vertu du Privacy Shield alors en place entre l’Union Européenne aux États-Unis."
 title: "Pinterest retire les mentions du Privacy Shield sans mettre à jour la date de modification"
 service: "Pinterest"
 terms_types: ["Privacy Policy"]

--- a/content/pages/fr/case-studies/protonmail-clarifies-its-privacy-policies.mdx
+++ b/content/pages/fr/case-studies/protonmail-clarifies-its-privacy-policies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Le 6 septembre 2021, ProtonMail a modifié ses politiques de confidentialité de sorte à clarifier les effets des lois suisses..."
+html_description: "Le 6 septembre 2021, ProtonMail a modifié ses politiques de confidentialité de sorte à clarifier les effets des lois suisses..."
 title: "Protonmail clarifie ses politiques de confidentialité"
 service: "Protonmail"
 terms_types: ["Privacy Policy"]

--- a/content/pages/fr/case-studies/qwant-details-data-shared-with-microsoft.mdx
+++ b/content/pages/fr/case-studies/qwant-details-data-shared-with-microsoft.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Le 2 novembre 2021, Qwant précise dans sa politique de vie privée, le type de données qu’elle transmet à son partenaire Microsoft « pour la sécurité et la fiabilité de ses services »."
+html_description: "Le 2 novembre 2021, Qwant précise dans sa politique de vie privée, le type de données qu’elle transmet à son partenaire Microsoft « pour la sécurité et la fiabilité de ses services »."
 title: "Qwant détaille les données partagées avec Microsoft"
 service: "Qwant"
 terms_types: ["Privacy Policy"]

--- a/content/pages/fr/case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.mdx
+++ b/content/pages/fr/case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Twitter ajoute une nouvelle condition aux contestations de retrait de contenu enfreignant les droits d’auteur."
+html_description: "Twitter ajoute une nouvelle condition aux contestations de retrait de contenu enfreignant les droits d’auteur."
 title: "Twitter conditionne les demandes de retrait du contenu à un consentement juridictionnel"
 service: "Twitter"
 terms_types: ["Copyright Claims Policy"]

--- a/content/pages/fr/case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.mdx
+++ b/content/pages/fr/case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Twitter précise que les suspensions de compte pour infraction aux droits d’auteur ne peuvent avoir lieu qu’en cas d’infraction répétée et non plus qu’elles peuvent varier selon les services."
+html_description: "Twitter précise que les suspensions de compte pour infraction aux droits d’auteur ne peuvent avoir lieu qu’en cas d’infraction répétée et non plus qu’elles peuvent varier selon les services."
 title: "Twitter précise les conditions de suspension de compte et permet d’en faire appel"
 service: "Twitter"
 terms_types: ["Copyright Claims Policy"]

--- a/content/pages/fr/case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published.mdx
+++ b/content/pages/fr/case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published.mdx
@@ -1,5 +1,5 @@
 ---
-description: "YouTube interdit la divulgation d’informations « personnelles » d’une autre personne et non plus seulement des informations « confidentielles »"
+html_description: "YouTube interdit la divulgation d’informations « personnelles » d’une autre personne et non plus seulement des informations « confidentielles »"
 title: "YouTube interdit la publication des informations de santé par un tiers"
 service: "YouTube"
 terms_types: ["Community Guidelines - Harassment"]

--- a/content/pages/fr/case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals.mdx
+++ b/content/pages/fr/case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals.mdx
@@ -1,5 +1,5 @@
 ---
-description: "YouTube a modifié la présentation de son programme YouTube Trusted Flagger."
+html_description: "YouTube a modifié la présentation de son programme YouTube Trusted Flagger."
 title: "YouTube ferme aux individus son programme de signalement facilité de contenu"
 service: "YouTube"
 terms_types: ["Community Guidelines"]

--- a/content/pages/fr/subscribe/confirm.mdx
+++ b/content/pages/fr/subscribe/confirm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Confirmez votre abonnement"
+html_title: "Confirmez votre abonnement"
 permalink: "/souscrire/confirmation"
 ---
 # Presque terminé !

--- a/content/pages/fr/subscribe/done.mdx
+++ b/content/pages/fr/subscribe/done.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Merci pour votre abonnement !"
+html_title: "Merci pour votre abonnement !"
 permalink: "/souscrire/confirme"
 ---
 # Votre inscription est confirmée !

--- a/content/pages/fr/subscribe/french-elections.mdx
+++ b/content/pages/fr/subscribe/french-elections.mdx
@@ -1,5 +1,5 @@
 ---
-title: "S'inscrire aux mémos France Élections"
+html_title: "S'inscrire aux mémos France Élections"
 permalink: "/souscrire/elections-francaises"
 ---
 # Mémos France Élections

--- a/content/parts/en/budget.mdx
+++ b/content/parts/en/budget.mdx
@@ -1,4 +1,6 @@
-<h1 className="mb__0">Budget</h1>
+---
+title: "Budget"
+---
 
 <p className="text__smallcaps mb__0">Last updated: December 2022</p>
 

--- a/content/parts/en/media.mdx
+++ b/content/parts/en/media.mdx
@@ -1,5 +1,4 @@
 ---
-title: "Media"
 hero.title: "Media"
 ---
 

--- a/content/parts/en/stats.mdx
+++ b/content/parts/en/stats.mdx
@@ -1,4 +1,6 @@
-# Impact and effort measurement
+---
+title: "Impact and effort measurement"
+---
 
 **Open Terms Archive's mission is to shift the power balance from large platforms to their users and regulators.** Measuring the specific impact of Open Terms Archive in such a broad task is difficult, if not impossible. Despite these limitations, we seek to measure the effect of our efforts, both to maximise it and out of accountability to the entities that trust us.
 

--- a/content/parts/fr/budget.mdx
+++ b/content/parts/fr/budget.mdx
@@ -1,5 +1,6 @@
-
-<h1 className="mb__0">Budget</h1>
+---
+title: "Budget"
+---
 
 <p className="text__smallcaps mb__0">Dernière mise à jour : décembre 2022</p>
 

--- a/content/parts/fr/media.mdx
+++ b/content/parts/fr/media.mdx
@@ -1,5 +1,4 @@
 ---
-title: "Média"
 hero.title: "Média"
 ---
 

--- a/content/parts/fr/stats.mdx
+++ b/content/parts/fr/stats.mdx
@@ -1,4 +1,6 @@
-# Mesures d'effort et d'impact
+---
+title: "Mesures d'effort et d'impact"
+---
 
 **Open Terms Archive a pour mission de rééquilibrer le rapport de force entre les grandes plateformes et leurs utilisateurs et les régulateurs.** Mesurer l’impact spécifique d’Open Terms Archive dans une tâche aussi large est délicat, voire impossible. Malgré ces limites, nous cherchons à mesurer l’effet de nos efforts, à la fois pour les maximiser et par redevabilité vis-à-vis des entités qui nous font confiance.
 

--- a/locales/en/budget.json
+++ b/locales/en/budget.json
@@ -1,6 +1,5 @@
 {
   "totalExpendituresGraph.axis.left.legend": "cumulative total in €",
-  "seo.title": "Budget",
   "funding-sources.meae": "🇫🇷🏛 French Ministry for Europe and Foreign Affairs",
   "funding-sources.france-relance": "🇪🇺🏛 French Covid Recovery Fund",
   "funding-sources.reset": "🇺🇸🏦 Reset",

--- a/locales/en/stats.json
+++ b/locales/en/stats.json
@@ -11,6 +11,5 @@
   "numbers.block5.title": "5 reuses",
   "numbers.block6.desc": "maintained by various partners",
   "numbers.block6.title": "6 instances",
-  "numbers.title": "The Open Terms Archive ecosystem as of March 2022",
-  "seo.title": "Statistics"
+  "numbers.title": "The Open Terms Archive ecosystem as of March 2022"
 }

--- a/locales/fr/budget.json
+++ b/locales/fr/budget.json
@@ -1,6 +1,5 @@
 {
   "totalExpendituresGraph.axis.left.legend": "total cumulé en €",
-  "seo.title": "Budget",
   "funding-sources.meae": "🇫🇷🏛 Ministère de l’Europe et des Affaires Étrangères",
   "funding-sources.france-relance": "🇪🇺🏛 France Relance",
   "funding-sources.reset": "🇺🇸🏦 Reset",

--- a/locales/fr/stats.json
+++ b/locales/fr/stats.json
@@ -11,6 +11,5 @@
   "numbers.block5.title": "5 réutilisations",
   "numbers.block6.desc": "maintenues par divers partenaires",
   "numbers.block6.title": "6 instances",
-  "numbers.title": "L’écosystème Open Terms Archive au mois de mars 2022",
-  "seo.title": "Statistiques"
+  "numbers.title": "L’écosystème Open Terms Archive au mois de mars 2022"
 }

--- a/src/pages/[...paths].tsx
+++ b/src/pages/[...paths].tsx
@@ -25,7 +25,10 @@ export default function StaticPage({ mdxContent }: WithMdxResult) {
   const { t } = useTranslation();
 
   return (
-    <Layout title={frontmatter['title']} desc={frontmatter['description']}>
+    <Layout
+      title={frontmatter['html_title'] ?? frontmatter['title'] ?? frontmatter['hero.title']}
+      desc={frontmatter['html_description'] ?? frontmatter['hero.subtitle']}
+    >
       {frontmatter['hero.title'] && (
         <Container layout="wide" dark={true} paddingY={false}>
           <Container gridCols="12" gridGutters="11" flex={true} paddingX={false} dark={true}>

--- a/src/pages/budget.tsx
+++ b/src/pages/budget.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import TextContent from 'modules/Common/components/TextContent';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { useTranslation } from 'modules/I18n';
 
 const TotalExpendituresGraph = dynamic(
   () => import('modules/Common/components/TotalExpendituresGraph'),

--- a/src/pages/budget.tsx
+++ b/src/pages/budget.tsx
@@ -24,13 +24,17 @@ export default function BudgetPage({
   totalExpendituresData,
   accumulatedExpenditures,
 }: WithMdxResult & ExpensesData) {
-  const { t } = useTranslation();
+  const { frontmatter = {} } = mdxContent || {};
   const router = useRouter();
 
   return (
-    <Layout title={t('budget:seo.title')}>
+    <Layout
+      title={frontmatter['html_title'] ?? frontmatter['title'] ?? frontmatter['hero.title']}
+      desc={frontmatter['html_description'] ?? frontmatter['hero.subtitle']}
+    >
       <Container gridCols="12" gridGutters="11">
         <TextContent>
+          {frontmatter.title && <h1 className="mb__0">{frontmatter.title}</h1>}
           <MDXRemote
             {...(mdxContent as any)}
             components={{

--- a/src/pages/case-studies/[...paths].tsx
+++ b/src/pages/case-studies/[...paths].tsx
@@ -37,7 +37,7 @@ export default function CaseStudyPage({ mdxContent }: WithMdxResult) {
 
   return (
     <Layout
-      title={frontmatter['html_title'] ?? frontmatter['title']}
+      title={frontmatter['html_title'] ?? frontmatter['title'] ?? frontmatter['hero.title']}
       desc={frontmatter['html_description']}
     >
       {frontmatter['hero.title'] && (

--- a/src/pages/case-studies/[...paths].tsx
+++ b/src/pages/case-studies/[...paths].tsx
@@ -36,7 +36,10 @@ export default function CaseStudyPage({ mdxContent }: WithMdxResult) {
   });
 
   return (
-    <Layout title={frontmatter['title']} desc={frontmatter['description']}>
+    <Layout
+      title={frontmatter['html_title'] ?? frontmatter['title']}
+      desc={frontmatter['html_description']}
+    >
       {frontmatter['hero.title'] && (
         <Container layout="wide" dark={true} paddingY={false}>
           <Container gridCols="12" gridGutters="11" flex={true} paddingX={false} dark={true}>

--- a/src/pages/media.tsx
+++ b/src/pages/media.tsx
@@ -20,10 +20,13 @@ export default function MediaPage({ mdxContent }: WithMdxResult) {
   const { t } = useTranslation();
 
   return (
-    <Layout title={frontmatter['title']} desc={frontmatter['description']}>
+    <Layout
+      title={frontmatter['html_title'] ?? frontmatter['title'] ?? frontmatter['hero.title']}
+      desc={frontmatter['html_description'] ?? frontmatter['hero.subtitle']}
+    >
       <Container layout="wide" paddingY={false} dark={true}>
         <Container gridCols="12" gridGutters="11" flex={true} paddingX={false}>
-          <Hero title={frontmatter['title']}></Hero>
+          <Hero title={frontmatter['hero.title']}></Hero>
         </Container>
       </Container>
 

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -11,10 +11,15 @@ import { useTranslation } from 'modules/I18n';
 
 export default function StatsPage({ mdxContent }: WithMdxResult) {
   const { t } = useTranslation();
+  const { frontmatter = {} } = mdxContent || {};
   return (
-    <Layout title={t('stats:seo.title')}>
+    <Layout
+      title={frontmatter['html_title'] ?? frontmatter['title'] ?? frontmatter['hero.title']}
+      desc={frontmatter['html_description'] ?? frontmatter['hero.subtitle']}
+    >
       <Container gridCols="10" gridGutters="9">
         <TextContent>
+          {frontmatter.title && <h1>{frontmatter.title}</h1>}
           {mdxContent && <MDXRemote {...mdxContent} components={{ LinkIcon }} />}
         </TextContent>
       </Container>


### PR DESCRIPTION
That changeset:
 - to facilitate contribution, moves SEO title declarations present in translation files to the corresponding yaml file 
 - to avoid confusion, rename `description` frontmatter keys to `html_description` and add `html_title` key which allows to declare `<title>` value independently of the page title `<h1>`
 - remove [duplicate title](https://opentermsarchive.org/about) 
 
Which allows us to formalize the following behavior:
- the html `<title>` tag takes the value of `html_title` key. If empty uses the first key declared in this order: `title`, `hero.title`.
- the html `<meta name="description" .. />` tag takes the value of `html_description` key. If empty uses `hero.subtitle`.