### PR TITLE
Add missing HTML descriptions

### DIFF
--- a/content/pages/en/about.mdx
+++ b/content/pages/en/about.mdx
@@ -1,5 +1,5 @@
 ---
-html_title: "About Open Terms Archive"
+html_title: "About"
 html_description: Open Terms Archive is free and open source software aiming at becoming a digital common.
 grid.cols: 9
 grid.gutters: 8

--- a/content/pages/en/about.mdx
+++ b/content/pages/en/about.mdx
@@ -1,4 +1,6 @@
 ---
+html_title: "About Open Terms Archive"
+html_description: Open Terms Archive is free and open source software aiming at becoming a digital common.
 grid.cols: 9
 grid.gutters: 8
 ---

--- a/content/pages/en/accessibility.mdx
+++ b/content/pages/en/accessibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Accessibility Statement"
+html_description: The accessibility statement that applies to Open Terms Archive website.
 ---
 
 Established on June 15, 2022.

--- a/content/pages/en/domain/compliance.mdx
+++ b/content/pages/en/domain/compliance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact on compliance
-html_description: Open Terms Archive impact on compliance.
+html_description: Leverage a database of terms of service changes to assess the compliance of online service providers with regulation
 domain: compliance
 related_collections:
   - p2b-compliance

--- a/content/pages/en/domain/compliance.mdx
+++ b/content/pages/en/domain/compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact on compliance
+html_description: Open Terms Archive impact on compliance.
 domain: compliance
 related_collections:
   - p2b-compliance

--- a/content/pages/en/domain/consumer-protection.mdx
+++ b/content/pages/en/domain/consumer-protection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact on consumer protection
-html_description: Open Terms Archive impact on consumer protection.
+html_description: Leverage a database of terms of service changes to measure how loyal service providers are to their customers
 domain: consumer protection
 related_collections:
   - france

--- a/content/pages/en/domain/consumer-protection.mdx
+++ b/content/pages/en/domain/consumer-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact on consumer protection
+html_description: Open Terms Archive impact on consumer protection.
 domain: consumer protection
 related_collections:
   - france

--- a/content/pages/en/domain/disinformation.mdx
+++ b/content/pages/en/domain/disinformation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact on mis- and disinformation
+html_description: Mis- and disinformation are typically addressed through reactive measures against specific attacks or proactive prevention efforts.
 domain: disinformation
 related_collections:
   - pga

--- a/content/pages/en/domain/disinformation.mdx
+++ b/content/pages/en/domain/disinformation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact on mis- and disinformation
-html_description: Mis- and disinformation are typically addressed through reactive measures against specific attacks or proactive prevention efforts.
+html_description: Leverage a database of terms of service changes for online platforms risk assessment towards systemic risks such as disinformation
 domain: disinformation
 related_collections:
   - pga

--- a/content/pages/en/domain/generative-ai.mdx
+++ b/content/pages/en/domain/generative-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call for funders and contributors on generative AI industry
-html_description: The generative AI industry is a globally relevant target for Open Terms Archive, considering on the one hand that it is so emergent it is mostly unregulated and will thus evolve very fast.
+html_description: Leverage a database of generative AI services terms to design AI regulation and assess upcoming compliance
 domain: generative ai
 ---
 

--- a/content/pages/en/domain/generative-ai.mdx
+++ b/content/pages/en/domain/generative-ai.mdx
@@ -1,5 +1,6 @@
 ---
 title: Call for funders and contributors on generative AI industry
+html_description: The generative AI industry is a globally relevant target for Open Terms Archive, considering on the one hand that it is so emergent it is mostly unregulated and will thus evolve very fast.
 domain: generative ai
 ---
 

--- a/content/pages/en/domain/privacy.mdx
+++ b/content/pages/en/domain/privacy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact on personal data protection
+html_description: Open Terms Archive impact on personal data protection.
 domain: privacy
 related_collections:
   - pga

--- a/content/pages/en/domain/privacy.mdx
+++ b/content/pages/en/domain/privacy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact on personal data protection
-html_description: Open Terms Archive impact on personal data protection.
+html_description: Leverage a database of terms of service changes to identify privacy practices and compliance to personal data protection frameworks such as GDPR, CCPA or LGPD
 domain: privacy
 related_collections:
   - pga

--- a/content/pages/en/impact.mdx
+++ b/content/pages/en/impact.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact model
+html_description: Open Terms Archive addresses a critical gap in the ability of activists, journalists, researchers, lawmakers and regulators to analyse and influence the rules of online services.
 grid.cols: 8
 grid.gutters: 7
 ---

--- a/content/pages/en/legal-notice.mdx
+++ b/content/pages/en/legal-notice.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Legal notice of Open Terms Archive"
+html_description: This page contains all the necessary legal information.
 ---
 
 ## Publisher of the Platform

--- a/content/pages/en/legal-notice.mdx
+++ b/content/pages/en/legal-notice.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Legal notice of Open Terms Archive"
-html_description: This page contains all the necessary legal information.
+html_description: Publishing and hosting identification
 ---
 
 ## Publisher of the Platform

--- a/content/pages/en/privacy-policy.mdx
+++ b/content/pages/en/privacy-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Privacy Policy"
+html_description: This privacy policy explains how, why and under what conditions the Open Terms Archive site collects personal information and how it is used.
 ---
 
 <p className="text__smallcaps mb__3XL">Last updated: August 19, 2021</p>

--- a/content/pages/en/subscribe/confirm.mdx
+++ b/content/pages/en/subscribe/confirm.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "Confirm your subscription"
+html_description: You should receive an email with a confirmation link.
 ---
 
 # Almost done!

--- a/content/pages/en/subscribe/done.mdx
+++ b/content/pages/en/subscribe/done.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "Thanks for subscribing!"
+html_description: You are now subscribed.
 ---
 # You are now subscribed!
 

--- a/content/pages/en/subscribe/french-elections.mdx
+++ b/content/pages/en/subscribe/french-elections.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "Subscribe to French Elections Memos"
+html_description: These Memos are short analyses published within 48 hours of the detection of changes in the contractual documents of five platforms that could have a systemic impact on the 2022 French elections
 ---
 # French Elections Memos
 

--- a/content/pages/fr/about.mdx
+++ b/content/pages/fr/about.mdx
@@ -1,4 +1,6 @@
 ---
+html_title: "À propos d'Open Terms Archive"
+html_description: Open Terms Archive est un logiciel libre et ouvert visant à devenir un commun numérique.
 permalink: "/a-propos"
 grid.cols: 9
 grid.gutters: 8

--- a/content/pages/fr/about.mdx
+++ b/content/pages/fr/about.mdx
@@ -1,5 +1,5 @@
 ---
-html_title: "À propos d'Open Terms Archive"
+html_title: "À propos"
 html_description: Open Terms Archive est un logiciel libre et ouvert visant à devenir un commun numérique.
 permalink: "/a-propos"
 grid.cols: 9

--- a/content/pages/fr/accessibility.mdx
+++ b/content/pages/fr/accessibility.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Déclaration d’accessibilité"
+html_description: La déclaration d'accessibilité qui s'applique au site internet d'Open Terms Archive.
 permalink: "/accessibilite"
 ---
 

--- a/content/pages/fr/domain/compliance.mdx
+++ b/content/pages/fr/domain/compliance.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact sur la conformité
+html_description: L'impact d'Open Terms Archive sur la conformité.
 domain: compliance
 related_collections:
   - p2b-compliance

--- a/content/pages/fr/domain/compliance.mdx
+++ b/content/pages/fr/domain/compliance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact sur la conformité
-html_description: L'impact d'Open Terms Archive sur la conformité.
+html_description: Exploitez une base de données des changements de CGUs pour évaluer la conformité des services en ligne avec la réglementation en vigueur
 domain: compliance
 related_collections:
   - p2b-compliance

--- a/content/pages/fr/domain/consumer-protection.mdx
+++ b/content/pages/fr/domain/consumer-protection.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact sur la protection des consommateurs
-html_description: L'impact d'Open Terms Archive sur la protection des consommateurs.
+html_description: Exploitez une base de données des changements de CGUs pour mesurer la loyauté des services en ligne vis à vis de leurs consommateurs
 domain: consumer protection
 related_collections:
   - france

--- a/content/pages/fr/domain/consumer-protection.mdx
+++ b/content/pages/fr/domain/consumer-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact sur la protection des consommateurs
+html_description: L'impact d'Open Terms Archive sur la protection des consommateurs.
 domain: consumer protection
 related_collections:
   - france

--- a/content/pages/fr/domain/disinformation.mdx
+++ b/content/pages/fr/domain/disinformation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact sur les manipulations de l'information
-html_description: Les manipulations de l'information sont généralement abordés par le biais de mesures réactives contre des attaques spécifiques ou d'efforts de prévention proactifs.
+html_description: Exploitez une base de données des changements de CGUs pour produire des évaluations de risque systémique pour la désinformation sur les grandes plateformes
 domain: disinformation
 related_collections:
   - pga

--- a/content/pages/fr/domain/disinformation.mdx
+++ b/content/pages/fr/domain/disinformation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact sur les manipulations de l'information
+html_description: Les manipulations de l'information sont généralement abordés par le biais de mesures réactives contre des attaques spécifiques ou d'efforts de prévention proactifs.
 domain: disinformation
 related_collections:
   - pga

--- a/content/pages/fr/domain/generative-ai.mdx
+++ b/content/pages/fr/domain/generative-ai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Appel aux financeurs et aux contributeurs sur l'industrie de l'IA générative
-html_description: L'industrie de l'IA générative représente une cible mondiale pertinente pour Open Terms Archive en raison de son caractère émergent qui la rend pratiquement non réglementée et de sa capacité à évoluer rapidement.
+html_description: Exploitez une base de données des CGUs de services d'IA générative pour concevoir une réglementation adaptée et vérifier son adoption
 domain: generative ai
 ---
 

--- a/content/pages/fr/domain/generative-ai.mdx
+++ b/content/pages/fr/domain/generative-ai.mdx
@@ -1,5 +1,6 @@
 ---
 title: Appel aux financeurs et aux contributeurs sur l'industrie de l'IA générative
+html_description: L'industrie de l'IA générative représente une cible mondiale pertinente pour Open Terms Archive en raison de son caractère émergent qui la rend pratiquement non réglementée et de sa capacité à évoluer rapidement.
 domain: generative ai
 ---
 

--- a/content/pages/fr/domain/privacy.mdx
+++ b/content/pages/fr/domain/privacy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Impact sur la protection des données personnelles
-html_description: L'impact d'Open Terms Archive sur la protection des données personnelles.
+html_description: Exploitez une base de données des changements de CGUs pour évaluer la protection des données personnelles des plateformes et leur conformité RGPD ou CCPA
 domain: privacy
 related_collections:
   - pga

--- a/content/pages/fr/domain/privacy.mdx
+++ b/content/pages/fr/domain/privacy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impact sur la protection des données personnelles
+html_description: L'impact d'Open Terms Archive sur la protection des données personnelles.
 domain: privacy
 related_collections:
   - pga

--- a/content/pages/fr/impact.mdx
+++ b/content/pages/fr/impact.mdx
@@ -1,5 +1,6 @@
 ---
 title: Modèle d'impact
+html_description: Open Terms Archive comble une lacune critique dans la capacité des militants, journalistes, chercheurs, législateurs et régulateurs à comprendre, analyser et influencer les règles des services en ligne.
 grid.cols: 8
 grid.gutters: 7
 ---

--- a/content/pages/fr/legal-notice.mdx
+++ b/content/pages/fr/legal-notice.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Mentions légales d'Open Terms Archive"
+html_description: Cette page présente les informations légales nécessaires.
 permalink: "/mentions-legales"
 ---
 

--- a/content/pages/fr/legal-notice.mdx
+++ b/content/pages/fr/legal-notice.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mentions légales d'Open Terms Archive"
-html_description: Cette page présente les informations légales nécessaires.
+html_description: Direction de publication et hébergeur
 permalink: "/mentions-legales"
 ---
 

--- a/content/pages/fr/privacy-policy.mdx
+++ b/content/pages/fr/privacy-policy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Politique de confidentialité"
+html_description: Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive collecte des informations personnelles, et la finalité du traitement de ces dernières.
 permalink: "/politique-de-confidentialite"
 ---
 

--- a/content/pages/fr/subscribe/confirm.mdx
+++ b/content/pages/fr/subscribe/confirm.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "Confirmez votre abonnement"
+html_description: Vous devriez recevoir un courriel avec un lien de confirmation.
 permalink: "/souscrire/confirmation"
 ---
 # Presque terminé !

--- a/content/pages/fr/subscribe/done.mdx
+++ b/content/pages/fr/subscribe/done.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "Merci pour votre abonnement !"
+html_description: Votre inscription est confirmée.
 permalink: "/souscrire/confirme"
 ---
 # Votre inscription est confirmée !

--- a/content/pages/fr/subscribe/french-elections.mdx
+++ b/content/pages/fr/subscribe/french-elections.mdx
@@ -1,5 +1,6 @@
 ---
 html_title: "S'inscrire aux mémos France Élections"
+html_description: Ces Mémos sont de courtes analyses publiées dans les 48 heures suivant la détection de changements dans les documents contractuels de cinq plateformes qui pourraient avoir un impact systémique sur les élections françaises de 2022.
 permalink: "/souscrire/elections-francaises"
 ---
 # Mémos France Élections

--- a/content/parts/en/budget.mdx
+++ b/content/parts/en/budget.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Budget"
+html_description: Open Terms Archive budget presentation
 ---
 
 <p className="text__smallcaps mb__0">Last updated: August 2023</p>

--- a/content/parts/en/budget.mdx
+++ b/content/parts/en/budget.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Budget"
-html_description: Open Terms Archive budget presentation
+html_description: Total costs of building and operating Open Terms Archive
 ---
 
 <p className="text__smallcaps mb__0">Last updated: August 2023</p>

--- a/content/parts/en/media.mdx
+++ b/content/parts/en/media.mdx
@@ -1,6 +1,6 @@
 ---
 hero.title: "Media"
-html_description: Press area of Open Terms Archive
+html_description: Logos, copywriting rules and media releases
 ---
 
 ## Copywriting

--- a/content/parts/en/media.mdx
+++ b/content/parts/en/media.mdx
@@ -1,5 +1,6 @@
 ---
 hero.title: "Media"
+html_description: Press area of Open Terms Archive
 ---
 
 ## Copywriting

--- a/content/parts/en/stats.mdx
+++ b/content/parts/en/stats.mdx
@@ -1,6 +1,6 @@
 ---
 title: Size of the federation
-html_description: Some numbers that give an idea of Open Terms Archive growing size
+html_description: Total numbers of tracked terms, services, analyses and publications in the Open Terms Archive ecosystem
 ---
 
 Open Terms Archive is a decentralised, federated ecosystem that publicly records and analyses the terms of services of online services in different languages and countries several times a day, increasing their readability and highlighting their changes. It is designed as a tool to steer platform governance towards increased accountability, improved legislation and stronger regulatory compliance. These numbers give an idea of its growing size. [Read more on our impact model](/impact).

--- a/content/parts/en/stats.mdx
+++ b/content/parts/en/stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: Size of the federation
+html_description: Some numbers that give an idea of Open Terms Archive growing size
 ---
 
 Open Terms Archive is a decentralised, federated ecosystem that publicly records and analyses the terms of services of online services in different languages and countries several times a day, increasing their readability and highlighting their changes. It is designed as a tool to steer platform governance towards increased accountability, improved legislation and stronger regulatory compliance. These numbers give an idea of its growing size. [Read more on our impact model](/impact).

--- a/content/parts/fr/budget.mdx
+++ b/content/parts/fr/budget.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Budget"
+html_description: Présentation du budget d'Open Terms Archive
 ---
 
 <p className="text__smallcaps mb__0">Dernière mise à jour : août 2023</p>

--- a/content/parts/fr/budget.mdx
+++ b/content/parts/fr/budget.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Budget"
-html_description: Présentation du budget d'Open Terms Archive
+html_description: Coût total de développement et d'opération d'Open Terms Archive
 ---
 
 <p className="text__smallcaps mb__0">Dernière mise à jour : août 2023</p>

--- a/content/parts/fr/media.mdx
+++ b/content/parts/fr/media.mdx
@@ -1,5 +1,6 @@
 ---
 hero.title: "Média"
+html_description: Espace presse d'Open Terms Archive
 ---
 
 ## Règles de rédaction

--- a/content/parts/fr/media.mdx
+++ b/content/parts/fr/media.mdx
@@ -1,6 +1,6 @@
 ---
 hero.title: "Média"
-html_description: Espace presse d'Open Terms Archive
+html_description: Logos, règles de rédaction et communiqués de presse
 ---
 
 ## Règles de rédaction

--- a/content/parts/fr/stats.mdx
+++ b/content/parts/fr/stats.mdx
@@ -1,6 +1,6 @@
 ---
 title: Taille de la fédération
-html_description: Quelques chiffres qui donnent une idée de la taille croissante d'Open Terms Archive
+html_description: Nombre total de documents, services, études de cas et analyses dans l'écosystème Open Terms Archive
 ---
 
 Open Terms Archive est un écosystème décentralisé et fédéré qui enregistre publiquement les conditions d'utilisation des services en ligne dans différentes langues et différents pays plusieurs fois par jour, en améliorant leur lisibilité et en mettant en évidence leurs modifications. Il est conçue comme un outil permettant d'orienter la gouvernance des plateformes vers une plus grande responsabilité, une meilleure législation et une plus grande conformité réglementaire. Ces chiffres donnent une idée de sa taille croissante. [Pour en savoir plus, consultez notre modèle d'impact](/fr/impact).

--- a/content/parts/fr/stats.mdx
+++ b/content/parts/fr/stats.mdx
@@ -1,5 +1,6 @@
 ---
 title: Taille de la fédération
+html_description: Quelques chiffres qui donnent une idée de la taille croissante d'Open Terms Archive
 ---
 
 Open Terms Archive est un écosystème décentralisé et fédéré qui enregistre publiquement les conditions d'utilisation des services en ligne dans différentes langues et différents pays plusieurs fois par jour, en améliorant leur lisibilité et en mettant en évidence leurs modifications. Il est conçue comme un outil permettant d'orienter la gouvernance des plateformes vers une plus grande responsabilité, une meilleure législation et une plus grande conformité réglementaire. Ces chiffres donnent une idée de sa taille croissante. [Pour en savoir plus, consultez notre modèle d'impact](/fr/impact).


### PR DESCRIPTION
That changeset correct website pages metadata, especially the `<meta name="description"`> content.