### PR TITLE
Fix error 404 on product newsletter confirmation

### DIFF
--- a/content/pages/en/subscribe/confirm.mdx
+++ b/content/pages/en/subscribe/confirm.mdx
@@ -1,0 +1,11 @@
+---
+html_title: "Confirm your subscription"
+---
+
+# Almost done!
+
+**You should receive an email with a confirmation link.**
+
+To protect recipients from unwanted emails, we make sure the email address you gave wants to be subscribed. Click the link in the email we just sent you to confirm subscription 🙂
+
+If you do not receive this confirmation email, [contact us](mailto:contact@opentermsarchive.org).

--- a/content/pages/en/subscribe/done.mdx
+++ b/content/pages/en/subscribe/done.mdx
@@ -1,0 +1,6 @@
+---
+html_title: "Thanks for subscribing!"
+---
+# You are now subscribed!
+
+We always welcome your feedback. Please reply to any of the emails you get to tell us how we could make them better 🙂

--- a/content/pages/fr/subscribe/confirm.mdx
+++ b/content/pages/fr/subscribe/confirm.mdx
@@ -1,0 +1,11 @@
+---
+html_title: "Confirmez votre abonnement"
+permalink: "/souscrire/confirmation"
+---
+# Presque terminé !
+
+**Vous devriez recevoir un courriel avec un lien de confirmation.**
+
+Pour protéger les destinataires de courriels non désirés, nous nous assurons que l'adresse que vous avez donnée souhaite être abonnée. Cliquez sur le lien dans le courriel que nous venons de vous envoyer pour confirmer l'abonnement 🙂
+
+Si vous ne recevez pas ce courriel de confirmation, [contactez-nous](mailto:contact@opentermsarchive.org).

--- a/content/pages/fr/subscribe/done.mdx
+++ b/content/pages/fr/subscribe/done.mdx
@@ -1,0 +1,7 @@
+---
+html_title: "Merci pour votre abonnement !"
+permalink: "/souscrire/confirme"
+---
+# Votre inscription est confirmée !
+
+Nous avons besoins de vos retours : répondez à n’importe lequel de nos emails pour nous dire comment nous pourrions les améliorer 🙂

--- a/content/pages/fr/subscribe/done.mdx
+++ b/content/pages/fr/subscribe/done.mdx
@@ -4,4 +4,4 @@ permalink: "/souscrire/confirme"
 ---
 # Votre inscription est confirmée !
 
-Nous avons besoins de vos retours : répondez à n’importe lequel de nos emails pour nous dire comment nous pourrions les améliorer 🙂
+Nous avons besoin de vos retours : répondez à n’importe lequel de nos courriels pour nous dire comment nous pourrions les améliorer 🙂


### PR DESCRIPTION
This reverts commit e7268d6aecbd5cc63569ac21048449361a8a871d, while leaving the confirmation page necessary after subscribing to the product newsletter.

It can be tested [here](https://opentermsarchive-org-pr249.osc-secnum-fr1.scalingo.io/subscribe/confirm).