### PR TITLE
Expose collection metadata API endpoints

### DIFF
--- a/locales/en/collections.json
+++ b/locales/en/collections.json
@@ -12,5 +12,6 @@
   "title": "We establish partnerships to cover different industries, languages and jurisdictions",
   "volunteer-contributors": "Volunteer contributors",
   "cta.download-dataset": "Download dataset",
-  "new_collections.title": "Want to track services for different languages, jurisdictions, or industries? Contact us to collaborate!"
+  "new_collections.title": "Want to track services for different languages, jurisdictions, or industries? Contact us to collaborate!",
+  "endpoint": "Metadata API"
 }

--- a/locales/fr/collections.json
+++ b/locales/fr/collections.json
@@ -12,5 +12,6 @@
   "title": "Nous établissons des partenariats pour couvrir différentes industries, langues et juridictions",
   "volunteer-contributors": "Contributeurs bénévoles",
   "cta.download-dataset": "Télécharger le jeu de données",
-  "new_collections.title": "Vous voulez suivre des services visant une autre langue, juridiction ou industrie ? Contactez-nous pour commencer à collaborer ! "
+  "new_collections.title": "Vous voulez suivre des services visant une autre langue, juridiction ou industrie ? Contactez-nous pour commencer à collaborer ! ",
+  "endpoint": "API de métadonnées"
 }

--- a/public/collections.json
+++ b/public/collections.json
@@ -43,7 +43,8 @@
         "name": "European Commission",
         "url": "https://ec.europa.eu/info/departments/communications-networks-content-and-technology_en"
       }
-    ]
+    ],
+    "endpoint": "http://vps-463f0baf.vps.ovh.net/api/v1/docs/"
   },
   "France Élections": {
     "id": "france-elections",
@@ -81,7 +82,8 @@
     "industries": {
       "en": "Online dating",
       "fr": "Rencontre en ligne"
-    }
+    },
+    "endpoint": "http://vps-99ae1d89.vps.ovh.net/api/v1/docs/"
   },
   "France": {
     "id": "france",
@@ -104,7 +106,8 @@
     "stats": {
       "services": "108",
       "documents": "216"
-    }
+    },
+    "endpoint": "http://198.244.142.9/api/v1/docs/"
   },
   "Contrib": {
     "id": "contrib",
@@ -117,7 +120,8 @@
     "stats": {
       "services": "299",
       "documents": "660"
-    }
+    },
+    "endpoint": "http://198.244.153.104/api/v1/docs/"
   },
   "Demo": {
     "id": "demo",
@@ -136,6 +140,7 @@
     "industries": {
       "en": "Services needed to operate the Open Terms Archive engine",
       "fr": "Services nécessaires au fonctionnement du moteur d'Open Terms Archive"
-    }
+    },
+    "endpoint": "http://162.19.74.224/api/v1/docs/"
   }
 }

--- a/src/modules/Common/components/Collections.tsx
+++ b/src/modules/Common/components/Collections.tsx
@@ -188,7 +188,7 @@ const Collections: React.FC<CollectionsProps> = ({
             {cardLink == 'dataset' && endpoint && (
               <div className="mt__S text__center">
                 <LinkIcon
-                  iconName="FiLayers"
+                  iconName="FiTool"
                   iconColor="var(--colorBlack400)"
                   href={endpoint}
                   target="_blank"

--- a/src/modules/Common/components/Collections.tsx
+++ b/src/modules/Common/components/Collections.tsx
@@ -43,6 +43,7 @@ interface Collection {
   stats: Stats;
   subscribeURL?: string;
   industries?: Industries;
+  endpoint?: string;
 }
 
 const Collections: React.FC<CollectionsProps> = ({
@@ -92,6 +93,7 @@ const Collections: React.FC<CollectionsProps> = ({
           stats,
           subscribeURL,
           industries,
+          endpoint,
         }: Collection = collection;
         const instanceSlug = slugify(name, { lower: true });
         const author =
@@ -183,6 +185,19 @@ const Collections: React.FC<CollectionsProps> = ({
                 </Link>
               )}
             </div>
+            {cardLink == 'dataset' && endpoint && (
+              <div className="mt__S text__center">
+                <LinkIcon
+                  iconName="FiLayers"
+                  iconColor="var(--colorBlack400)"
+                  href={endpoint}
+                  target="_blank"
+                  rel="noopener"
+                >
+                  {t('collections:endpoint')}
+                </LinkIcon>
+              </div>
+            )}
             {subscribeURL && (
               <div className="mt__2XS text__center">
                 <LinkIcon iconColor="var(--colorBlack400)" iconName="FiMail" href="/subscribe">


### PR DESCRIPTION
That changeset add a `endpoint` key to the catalog entries, display the `endpoint` in the instance cards and reference all existing endpoints.

![image](https://github.com/OpenTermsArchive/opentermsarchive.org/assets/364319/18823c37-f4a7-434f-a505-9e7e52d9e1f6)
