### PR TITLE
Mentions our own tracking terms

### DIFF
--- a/content/pages/en/privacy-policy.mdx
+++ b/content/pages/en/privacy-policy.mdx
@@ -3,9 +3,9 @@ title: "Privacy Policy"
 html_description: This privacy policy explains how, why and under what conditions the Open Terms Archive site collects personal information and how it is used.
 ---
 
-<p className="text__smallcaps mb__3XL">Last updated: August 19, 2021</p>
+<p className="text__smallcaps mb__3XL">Last updated: September 26, 2023</p>
 
-This privacy policy explains how, why and under what conditions the Open Terms Archive (OTA) site collects personal information and how it is used. Our privacy policy will change over time.
+This privacy policy explains how, why and under what conditions the Open Terms Archive (OTA) site collects personal information and how it is used. Our privacy policy will change over time. And of course, we also record the changes of [our own documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
 
 ## Personal data processed
 

--- a/content/pages/en/privacy-policy.mdx
+++ b/content/pages/en/privacy-policy.mdx
@@ -5,7 +5,7 @@ html_description: This privacy policy explains how, why and under what condition
 
 <p className="text__smallcaps mb__3XL">Last updated: September 26, 2023</p>
 
-This privacy policy explains how, why and under what conditions the Open Terms Archive (OTA) site collects personal information and how it is used. Our privacy policy will change over time. And of course, we also record the changes of [our own documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
+This privacy policy explains how, why and under what conditions the Open Terms Archive (OTA) site collects personal information and how it is used. Our privacy policy will change over time. And of course, we also record the changes of [our own documents](https://github.com/OpenTermsArchive/demo-versions/tree/main/Open%20Terms%20Archive) 😉
 
 ## Personal data processed
 

--- a/content/pages/en/privacy-policy.mdx
+++ b/content/pages/en/privacy-policy.mdx
@@ -10,7 +10,7 @@ This privacy policy explains how, why and under what conditions the OpenÂ TermsÂ
 ## Personal data processed
 
 When you subscribe to the document change tracking service, we collect your email address. This allows us to notify you when a modification is detected on the document you have selected.
-This email is stored in a Sendinblue list (https://www.sendinblue.com).
+This email is stored in a Brevo list (https://brevo.com).
 
 In accordance with Article 17 of the GDPR, everyone has the right to have their data erased. Users of this service whose personal data has been collected may request the deletion of such data by writing to the dedicated address: contact@opentermsarchive.org
 

--- a/content/pages/fr/privacy-policy.mdx
+++ b/content/pages/fr/privacy-policy.mdx
@@ -11,7 +11,7 @@ Cette politique de confidentialité explique de quelle manière, pour quelles ra
 ## Données à caractère personnel traitées
 
 Lorsque que vous souscrivez au service de suivi des modifications d'un document, nous collectons votre adresse email. Cela nous permet de vous avertir lorsqu'une modification est detectée sur le document que vous avez sélectionné.
-Cet email est stocké dans une liste d'un de nos sous-traitants Sendinblue (https://www.sendinblue.com).
+Cet email est stocké dans une liste d'un de nos sous-traitants Brevo (https://brevo.com).
 
 Conformément à l’article 17 du RGPD, tout un chacun a droit à l’effacement de ses données. Les utilisateurs de ce service dont les données personnelles ont été collectées, ont la possibilité de demander l’effacement de ces données en écrivant à l’adresse dédiée : contact@opentermsarchive.org
 

--- a/content/pages/fr/privacy-policy.mdx
+++ b/content/pages/fr/privacy-policy.mdx
@@ -6,7 +6,7 @@ permalink: "/politique-de-confidentialite"
 
 <p className="text__smallcaps mb__3XL">Dernière mise à jour : 26 septembre 2023</p>
 
-Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitement de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps. Et bien sûr, nous enregistrons également les changements de [nos propres documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
+Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitement de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps. Et bien sûr, nous enregistrons également les changements de [nos propres documents](https://github.com/OpenTermsArchive/demo-versions/tree/main/Open%20Terms%20Archive) 😉
 
 ## Données à caractère personnel traitées
 

--- a/content/pages/fr/privacy-policy.mdx
+++ b/content/pages/fr/privacy-policy.mdx
@@ -6,7 +6,7 @@ permalink: "/politique-de-confidentialite"
 
 <p className="text__smallcaps mb__3XL">Dernière mise à jour : 26 septembre 2023</p>
 
-Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitementy de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps. Et bien sûr, nous enregistrons également les changements de [nos propres documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
+Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitement de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps. Et bien sûr, nous enregistrons également les changements de [nos propres documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
 
 ## Données à caractère personnel traitées
 

--- a/content/pages/fr/privacy-policy.mdx
+++ b/content/pages/fr/privacy-policy.mdx
@@ -4,9 +4,9 @@ html_description: Cette politique de confidentialité explique de quelle manièr
 permalink: "/politique-de-confidentialite"
 ---
 
-<p className="text__smallcaps mb__3XL">Dernière mise à jour : 19 août 2021</p>
+<p className="text__smallcaps mb__3XL">Dernière mise à jour : 26 septembre 2023</p>
 
-Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitementy de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps.
+Cette politique de confidentialité explique de quelle manière, pour quelles raisons et dans quelles conditions le site d'Open Terms Archive (OTA) collecte des informations personnelles, et la finalité du traitementy de ces dernières. Notre politique de confidentialité est vouée à évoluer au fil du temps. Et bien sûr, nous enregistrons également les changements de [nos propres documents](https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive) 😉
 
 ## Données à caractère personnel traitées
 


### PR DESCRIPTION
That changeset add a sentence explaining that we also track our own documents, update the last updated dat, fix a typo and rename SIB to Brevo.

The link to `https://github.com/OpenTermsArchive/demo-versions/Open%20Terms%20Archive` is broken because we have just add the [tracking of our own terms](https://github.com/OpenTermsArchive/demo-declarations/commit/7d45cbd3ae30e6cf37e5925dacf3e06d81cadd4e). We have to wait for the first version to be published before merging that pull request.

