### PR TITLE
Initialises All Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ In `my-page.mdx`:
 
 See our [contributing guide](CONTRIBUTING.md).
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
 ---
 
 ## License

--- a/public/collections.json
+++ b/public/collections.json
@@ -122,7 +122,7 @@
       "services": "299",
       "documents": "660"
     },
-    "endpoint": "http://198.244.153.104/api/v1/docs/"
+    "endpoint": "http://51.89.224.102/api/v1/docs/"
   },
   "Demo": {
     "id": "demo",

--- a/public/collections.json
+++ b/public/collections.json
@@ -83,8 +83,7 @@
     "industries": {
       "en": "Online dating",
       "fr": "Rencontre en ligne"
-    },
-    "endpoint": "http://vps-99ae1d89.vps.ovh.net/api/v1/docs/"
+    }
   },
   "France": {
     "id": "france",


### PR DESCRIPTION
I've just installed the All Contributors bot on the repository and this pull request initialises the display of the list of contributors in the readme file.

Once that's merged, I'll add a first contributor with the bot, which will also generate the configuration file.