### PR TITLE
Improve italic readability

### DIFF
--- a/src/modules/Common/styles/elements/utility.css
+++ b/src/modules/Common/styles/elements/utility.css
@@ -291,5 +291,5 @@
 }
 
 .font-style__italic {
-  font-style: italic;
+  font-style: oblique 12deg;
 }


### PR DESCRIPTION
That changeset improve the readability of the italic font style and unify the rendering by using `font-style: oblique`(which is [well supported](https://caniuse.com/mdn-css_properties_font-style_oblique-angle) in last browsers versions) instead of `font-style: italic` because the italic style artificially simulated is not satisfying (see the first image below) and also because [Inter font](https://github.com/rsms/inter) does provide the possibility to use `ital` or `snlt` font variation settings.

From 
<img width="850" alt="image" src="https://github.com/OpenTermsArchive/opentermsarchive.org/assets/364319/ac0e5642-200c-4986-baa4-a53e22182050">

To
<img width="838" alt="image" src="https://github.com/OpenTermsArchive/opentermsarchive.org/assets/364319/dbb56fcb-da09-4d15-bbdb-0319afe72a19">
