### PR TITLE
Add subscribe pages

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -28,3 +28,6 @@ single-title:
   front_matter_title: "" # disable front matter title as a top level heading, see https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md025---multiple-top-level-headings-in-the-same-document
 
 heading-increment: false # allow to skip header levels
+
+no-trailing-punctuation:
+  punctuation: .,;:。，；

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -15,6 +15,11 @@ no-inline-html:
     - abbr
     - i
     - a
+    - form
+    - div
+    - input
+    - button
+    - p
 
 no-duplicate-header: false
 

--- a/config/_default/languages.fr.yaml
+++ b/config/_default/languages.fr.yaml
@@ -5,3 +5,4 @@ permalinks:
     case-studies: /etudes-de-cas/
   page:
     case-studies: /etudes-de-cas/:slug/
+    subscribe: /souscrire/:slug

--- a/content/subscribe/confirm.fr.md
+++ b/content/subscribe/confirm.fr.md
@@ -1,0 +1,13 @@
+---
+html_title: Confirmez votre abonnement
+html_description: Vous devriez recevoir un courriel avec un lien de confirmation.
+slug: /confirmation
+---
+
+# Presque terminé !
+
+**Vous devriez recevoir un courriel avec un lien de confirmation.**
+
+Pour protéger les destinataires de courriels non désirés, nous nous assurons que l'adresse que vous avez donnée souhaite être abonnée. Cliquez sur le lien dans le courriel que nous venons de vous envoyer pour confirmer l'abonnement 🙂
+
+Si vous ne recevez pas ce courriel de confirmation, [contactez-nous](mailto:{{< param "contact_email" >}}).

--- a/content/subscribe/confirm.fr.md
+++ b/content/subscribe/confirm.fr.md
@@ -2,6 +2,7 @@
 html_title: Confirmez votre abonnement
 html_description: Vous devriez recevoir un courriel avec un lien de confirmation.
 slug: /confirmation
+aliases: /fr/subscribe/confirm
 ---
 
 # Presque terminé !

--- a/content/subscribe/confirm.md
+++ b/content/subscribe/confirm.md
@@ -1,6 +1,7 @@
 ---
 html_title: Confirm your subscription
 html_description: You should receive an email with a confirmation link.
+aliases: /en/subscribe/confirm
 ---
 
 # Almost done!

--- a/content/subscribe/confirm.md
+++ b/content/subscribe/confirm.md
@@ -1,0 +1,12 @@
+---
+html_title: Confirm your subscription
+html_description: You should receive an email with a confirmation link.
+---
+
+# Almost done!
+
+**You should receive an email with a confirmation link.**
+
+To protect recipients from unwanted emails, we make sure the email address you gave wants to be subscribed. Click the link in the email we just sent you to confirm subscription 🙂
+
+If you do not receive this confirmation email, [contact us](mailto:{{< param "contact_email" >}}).

--- a/content/subscribe/done.fr.md
+++ b/content/subscribe/done.fr.md
@@ -1,0 +1,9 @@
+---
+html_title: Merci pour votre abonnement !
+html_description: Votre inscription est confirmée.
+slug: /confirme
+---
+
+# Votre inscription est confirmée !
+
+Nous avons besoin de vos retours : répondez à n’importe lequel de nos courriels pour nous dire comment nous pourrions les améliorer 🙂

--- a/content/subscribe/done.fr.md
+++ b/content/subscribe/done.fr.md
@@ -2,6 +2,7 @@
 html_title: Merci pour votre abonnement !
 html_description: Votre inscription est confirmée.
 slug: /confirme
+aliases: /fr/subscribe/done
 ---
 
 # Votre inscription est confirmée !

--- a/content/subscribe/done.md
+++ b/content/subscribe/done.md
@@ -1,6 +1,7 @@
 ---
 html_title: Thanks for subscribing!
 html_description: You are now subscribed.
+aliases: /en/subscribe/done
 ---
 
 # You are now subscribed!

--- a/content/subscribe/done.md
+++ b/content/subscribe/done.md
@@ -1,0 +1,8 @@
+---
+html_title: Thanks for subscribing!
+html_description: You are now subscribed.
+---
+
+# You are now subscribed!
+
+We always welcome your feedback. Please reply to any of the emails you get to tell us how we could make them better 🙂

--- a/content/subscribe/french-elections-2022.fr.md
+++ b/content/subscribe/french-elections-2022.fr.md
@@ -1,0 +1,27 @@
+---
+html_title: S'inscrire aux mémos France Élections
+html_description: Ces Mémos sont de courtes analyses publiées dans les 48 heures suivant la détection de changements dans les documents contractuels de cinq plateformes qui pourraient avoir un impact systémique sur les élections françaises de 2022.
+slug: /memos-elections-francaises-2022
+aliases: /fr/souscrire/elections-francaises
+---
+
+# Mémos France Élections
+
+Ces Mémos sont de courtes analyses publiées dans les 48 heures suivant la détection de changements dans les documents contractuels de
+cinq plateformes qui pourraient avoir un impact systémique sur les élections françaises de 2022 : Facebook, Twitter, Instagram, LinkedIn
+et YouTube. En vous abonnant, vous les recevrez directement dans votre boîte de réception.
+
+<form id="sib-form" method="POST" action="https://98bb6346.sibforms.com/serve/MUIEACNQpj-ZHUKKlyF0bfaAGsIMOfnk-nfryeUvMG2O64lDLnohxdkESevuVHk3fJj1yDmiSqJnybHo_REH1AA6o7MO2EoqDlx_zgWLvU2UUdqX0jeEPTbrBxXp3OXZryZqGkP5XCIITqQyfrvSjcE2uGsYLCRhBFbLQJYpvTZwKNl7xGl52vyOl5md3PNyJFFmpi0cRLs22GUe" class="mt__XL">
+  <div class="formfield mb__L">
+    <input type="email" id="EMAIL" name="EMAIL" autoComplete="off" placeholder="Email" data-required="true" required />
+  </div>
+  <div class="formfield formfield__alignRight">
+    <button class="button" form="sib-form" submit={true}>S'inscrire aux mémos</button>
+    <input type="checkbox" hidden={true} value="1" id="OPT_IN" name="OPT_IN" defaultChecked={true} required />
+    <input type="hidden" name="locale" value="fr" />
+  </div>
+</form>
+
+<p class="text__light">
+  Nous utilisons SendInBlue pour vous envoyer ces mémos. En cliquant sur le bouton ci-dessus, vous reconnaissez que votre adresse e-mail sera traitée conformément à leurs <a href="https://www.sendinblue.com/legal/termsofuse/" target="_blank">conditions générales d'utilisation</a> et <a href="{{< relref path="/privacy-policy" >}}" target="_blank">aux nôtres</a>.
+</p>

--- a/content/subscribe/french-elections-2022.fr.md
+++ b/content/subscribe/french-elections-2022.fr.md
@@ -16,8 +16,8 @@ et YouTube. En vous abonnant, vous les recevrez directement dans votre boîte de
     <input type="email" id="EMAIL" name="EMAIL" autoComplete="off" placeholder="Email" data-required="true" required />
   </div>
   <div class="formfield formfield__alignRight">
-    <button class="button" form="sib-form" submit={true}>S'inscrire aux mémos</button>
-    <input type="checkbox" hidden={true} value="1" id="OPT_IN" name="OPT_IN" defaultChecked={true} required />
+    <button class="button" form="sib-form" type="submit">S'inscrire aux mémos</button>
+    <input type="checkbox" hidden value="1" id="OPT_IN" name="OPT_IN" checked required />
     <input type="hidden" name="locale" value="fr" />
   </div>
 </form>

--- a/content/subscribe/french-elections-2022.md
+++ b/content/subscribe/french-elections-2022.md
@@ -1,0 +1,27 @@
+---
+html_title: Subscribe to French Elections Memos
+html_description: These Memos are short analyses published within 48 hours of the detection of changes in the contractual documents of five platforms that could have a systemic impact on the 2022 French elections
+slug: /memos-french-elections-2022
+aliases: /subscribe/french-elections
+---
+
+# French Elections Memos
+
+These Memos are short analyses published within 48 hours of the detection of changes in the contractual documents of
+five platforms that could have a systemic impact on the 2022 French elections: Facebook, Twitter, Instagram, LinkedIn
+and YouTube. By subscribing, you will receive them straight in your inbox.
+
+<form id="sib-form" method="POST" action="https://98bb6346.sibforms.com/serve/MUIEACNQpj-ZHUKKlyF0bfaAGsIMOfnk-nfryeUvMG2O64lDLnohxdkESevuVHk3fJj1yDmiSqJnybHo_REH1AA6o7MO2EoqDlx_zgWLvU2UUdqX0jeEPTbrBxXp3OXZryZqGkP5XCIITqQyfrvSjcE2uGsYLCRhBFbLQJYpvTZwKNl7xGl52vyOl5md3PNyJFFmpi0cRLs22GUe" class="mt__XL">
+  <div class="formfield mb__L">
+    <input type="email" id="EMAIL" name="EMAIL" autoComplete="off" placeholder="Email" data-required="true" required />
+  </div>
+  <div class="formfield formfield__alignRight">
+    <button class="button" form="sib-form" submit={true}>Subscribe to memos</button>
+    <input type="checkbox" hidden={true} value="1" id="OPT_IN" name="OPT_IN" defaultChecked={true} required />
+    <input type="hidden" name="locale" value="en" />
+  </div>
+</form>
+
+<p class="text__light">
+  We use SendInBlue to send you these memos. By clicking the button above, you acknowledge your email address will be processed in accordance to their <a href="https://www.sendinblue.com/legal/termsofuse/" target="_blank">terms of use</a> and <a href="{{< relref path="/privacy-policy" >}}" target="_blank">ours</a>.
+</p>

--- a/content/subscribe/french-elections-2022.md
+++ b/content/subscribe/french-elections-2022.md
@@ -16,8 +16,8 @@ and YouTube. By subscribing, you will receive them straight in your inbox.
     <input type="email" id="EMAIL" name="EMAIL" autoComplete="off" placeholder="Email" data-required="true" required />
   </div>
   <div class="formfield formfield__alignRight">
-    <button class="button" form="sib-form" submit={true}>Subscribe to memos</button>
-    <input type="checkbox" hidden={true} value="1" id="OPT_IN" name="OPT_IN" defaultChecked={true} required />
+    <button class="button" form="sib-form" type="submit">Subscribe to memos</button>
+    <input type="checkbox" hidden value="1" id="OPT_IN" name="OPT_IN" checked required />
     <input type="hidden" name="locale" value="en" />
   </div>
 </form>

--- a/themes/opentermsarchive/layouts/partials/head.html
+++ b/themes/opentermsarchive/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
-	<meta charset="utf-8" />
-	<title>Open Terms Archive - {{ .Title}}</title>
-	{{ with .Param "html_description"}}<meta name="description" content="{{ . }}" />{{ end }}
-	<meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta charset="utf-8" />
+  <title>{{ with .Param "html_title" }}{{ . }}{{ else }}{{ .Title }}{{ end }}</title>
+  {{ with .Param "html_description"}}<meta name="description" content="{{ . }}" />{{ end }}
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
 </head>


### PR DESCRIPTION
That changeset add the pages:
- /subscribe/memos-french-elections-2022/
- /subscribe/confirm/
- /subscribe/done/
- /fr/souscrire/memos-elections-francaises-2022/
- /fr/souscrire/confirmation/
- /fr/souscrire/confirme/

and use custom html `<title>` value when provided in frontmatter.