### PR TITLE
Ease listing engine contributors

### DIFF
--- a/.all-contributors.md
+++ b/.all-contributors.md
@@ -1,4 +1,4 @@
-This list of contributors is generated automatically by [All Contributors](https://allcontributors.org/). The output used in production is the JSON format, this file is not used.
+This file is required by [All Contributors](https://allcontributors.org/) to work properly and must not be deleted. Although it is automatically updated with the list of contributors, the actual output used in production is in JSON format and located in the `.all-contributorsrc` file.
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -332,7 +332,6 @@
     }
   ],
   "repoType": "github",
-  "commitConvention": "angular",
-  "commitType": "docs",
+  "commitConvention": "none",
   "contributorsPerLine": 7
 }

--- a/themes/opentermsarchive/layouts/partials/contributors.html
+++ b/themes/opentermsarchive/layouts/partials/contributors.html
@@ -1,43 +1,34 @@
-{{ $thumbnailWidth := or .thumbnailWidth 64 }}
-{{ $thumbnailHeight := or .thumbnailHeight 64 }}
+{{ $thumbnailWidth := default 64 .thumbnailWidth }}
+{{ $thumbnailHeight := default 64 .thumbnailHeight }}
 
-{{ $contributors := (resources.Get "allcontributorsrc.json" | unmarshal).contributors }}
+{{ $contributors := dict }}
+{{ range (resources.Get "allcontributorsrc.json" | unmarshal).contributors }}
+  {{ $contributors = $contributors | merge (dict .name .) }}
+{{ end }}
+
 {{ $allStaffNames := slice }}
 {{ range site.Data.staff }}{{ $allStaffNames = union $allStaffNames . }}{{ end }}
 
-{{ $remoteContributors := slice }}
 {{ with resources.GetRemote "https://raw.githubusercontent.com/OpenTermsArchive/engine/main/.all-contributorsrc" }}
   {{ with .Err }}
     {{ errorf "%s" . }}
   {{ else }}
-    {{ $remoteContributors = (.Content | unmarshal).contributors }}
+    {{ range (.Content | unmarshal).contributors }}
+      {{ $contributors =  $contributors | merge (dict .name .) }}
+    {{ end }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get the remote contributors" }}
 {{ end }}
 
-{{ $uniqueContributors := $contributors }}
-{{ range $remoteContributor := $remoteContributors }}
-  {{ $duplicate := false }}
-  {{ range $contributors }}
-    {{ if eq .name $remoteContributor.name }}
-      {{ $duplicate = true }}
-      {{ break }}
-    {{ end }}
-  {{ end }}
-  {{ if not $duplicate }}
-    {{ $uniqueContributors = $uniqueContributors | append $remoteContributor }}
-  {{ end }}
-{{ end }}
-
 {{ $filteredContributors := slice }}
-{{ range $contributor := $uniqueContributors }}
+{{ range $contributor := $contributors }}
   {{ with $.type }}
-    {{ if (in (index site.Data.staff .) $contributor.name)}}
+    {{ if (in (index site.Data.staff .) $contributor.name) }}
       {{ $filteredContributors = $filteredContributors | append $contributor }}
     {{ end }}
   {{ else }}
-    {{ if not (in $allStaffNames $contributor.name)}}
+    {{ if not (in $allStaffNames $contributor.name) }}
       {{ $filteredContributors = $filteredContributors | append $contributor }}
     {{ end }}
   {{ end }}

--- a/themes/opentermsarchive/layouts/partials/contributors.html
+++ b/themes/opentermsarchive/layouts/partials/contributors.html
@@ -1,30 +1,51 @@
-{{ $thumbnailWidth := 64 }}
-{{ if .thumbnailWidth }}{{ $thumbnailWidth = .thumbnailWidth }}{{ end }}
-{{ $thumbnailHeight := 64 }}
-{{ if .thumbnailHeight }}{{ $thumbnailHeight = .thumbnailHeight }}{{ end }}
+{{ $thumbnailWidth := or .thumbnailWidth 64 }}
+{{ $thumbnailHeight := or .thumbnailHeight 64 }}
 
-{{ $allcontributorsrc := resources.Get "allcontributorsrc.json" | unmarshal }}
-{{ $filteredContributors := slice }}
+{{ $contributors := (resources.Get "allcontributorsrc.json" | unmarshal).contributors }}
 {{ $allStaffNames := slice }}
 {{ range site.Data.staff }}{{ $allStaffNames = union $allStaffNames . }}{{ end }}
 
-{{ range $allcontributorsrc.contributors }}
-  {{ $contributor := . }}
+{{ $remoteContributors := slice }}
+{{ with resources.GetRemote "https://raw.githubusercontent.com/OpenTermsArchive/engine/main/.all-contributorsrc" }}
+  {{ with .Err }}
+    {{ errorf "%s" . }}
+  {{ else }}
+    {{ $remoteContributors = (.Content | unmarshal).contributors }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to get the remote contributors" }}
+{{ end }}
+
+{{ $uniqueContributors := $contributors }}
+{{ range $remoteContributor := $remoteContributors }}
+  {{ $duplicate := false }}
+  {{ range $contributors }}
+    {{ if eq .name $remoteContributor.name }}
+      {{ $duplicate = true }}
+      {{ break }}
+    {{ end }}
+  {{ end }}
+  {{ if not $duplicate }}
+    {{ $uniqueContributors = $uniqueContributors | append $remoteContributor }}
+  {{ end }}
+{{ end }}
+
+{{ $filteredContributors := slice }}
+{{ range $contributor := $uniqueContributors }}
   {{ with $.type }}
     {{ if (in (index site.Data.staff .) $contributor.name)}}
       {{ $filteredContributors = $filteredContributors | append $contributor }}
     {{ end }}
-   {{ else }}
+  {{ else }}
     {{ if not (in $allStaffNames $contributor.name)}}
       {{ $filteredContributors = $filteredContributors | append $contributor }}
     {{ end }}
-   {{ end }}
+  {{ end }}
 {{ end }}
 
 <div class="contributors {{ with .class }}{{ . }}{{ end }} {{ with .showInfo }}contributors--show-infos{{ end }}">
   <div class="contributors__items">
-    {{ range $filteredContributors }}
-      {{ $contributor := . }}
+    {{ range $contributor := $filteredContributors }}
       {{ $image := resources.Get (printf "/images/contributors/%s.jpg" ($contributor.name | urlize)) }}
       {{ with $contributor.avatar_url }}
         {{ $remoteImage := resources.GetRemote . }}


### PR DESCRIPTION
That changeset obtained contributors from [engine data](https://github.com/OpenTermsArchive/engine/blob/main/.all-contributorsrc) at build time, merged it with the website data and displayed them in the [About](https://opentermsarchive.org/en/about/) page. This ensures that contributors are listed only once.

Note that the remote contributors data will be obtained at each deployment (as they are not cached by `npm run build` command). On your local server, you can ignore the cache by using `--ignoreCache` Hugo option:  `npm run start:dev -- --ignoreCache`