### PR TITLE
Add authors to memos

### DIFF
--- a/content/memos/alibaba-adds-disease-outbreaks-to-its-disclaimer.fr.md
+++ b/content/memos/alibaba-adds-disease-outbreaks-to-its-disclaimer.fr.md
@@ -5,6 +5,7 @@ service: "Alibaba"
 terms_types: ["Terms of use"]
 dates: ["2020-06-23"]
 aliases: /fr/etudes-de-cas/alibaba-ajoute-les-epidemies-a-ses-clauses-dexclusion-de-responsabilite/
+author: Elsa Trujilo
 ---
 
 L’épidémie de Covid se lit jusque dans les conditions d’utilisation d’Alibaba : depuis le 6 mai 2020, la place de marché <a target="_blank" rel="noopener" href="https://github.com/ambanum/CGUs-data/commit/37503cb23">précise</a> dans les cas de force majeure dans lesquels elle n’est pas responsable des retards ou des échecs de commande.

--- a/content/memos/alibaba-adds-disease-outbreaks-to-its-disclaimer.md
+++ b/content/memos/alibaba-adds-disease-outbreaks-to-its-disclaimer.md
@@ -7,6 +7,7 @@ dates: ["2020-06-23"]
 aliases:
   - /case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer/
   - /en/case-studies/alibaba-adds-disease-outbreaks-to-its-disclaimer/
+author: Elsa Trujilo
 ---
 
 The impact of the Covid-19 pandemic can be read right into Alibaba's terms of service: since May 6, 2020, the marketplace <a target="_blank" rel="noopener" href="https://github.com/ambanum/CGUs-data/commit/37503cb23">specified</a> epidemics as cases of force majeure in which it is not responsible for order delays or failures.

--- a/content/memos/copyai-stops-abiding-with-the-eu-us-data-privacy-framework.md
+++ b/content/memos/copyai-stops-abiding-with-the-eu-us-data-privacy-framework.md
@@ -4,6 +4,7 @@ title: Copy.AI stops abiding with the EU-U.S. Data Privacy Framework
 service: Copy.AI
 terms_types: ["Privacy Policy"]
 dates: ["2023-10-17"]
+author: Bertille Gauducheau
 ---
 
 Copy.AI [erased](https://github.com/OpenTermsArchive/GenAI-versions/commit/c8a3f106587decf0cb6b5e0ce7695929d153a856) from its privacy policy its commitment to abide by the EU-U.S. Data Privacy Framework.

--- a/content/memos/doubao-expands-behavioral-data-collection-and-establishes-minimum-age.md
+++ b/content/memos/doubao-expands-behavioral-data-collection-and-establishes-minimum-age.md
@@ -4,6 +4,7 @@ title: Doubao expands behavioral data collection and establishes minimum age
 service: Doubao
 terms_types: ["Privacy Policy"]
 dates: ["2024-03-04"]
+author: Peijun Hu
 ---
 
 Doubao [expanded](https://github.com/OpenTermsArchive/GenAI-versions/commit/ada4e457907c93f9073efddf755c27ab3ff7ac58) the scope of data collection to include "input information", explicitly encompassing dialogue content and search text. To further broaden the coverage of behavioral information, it appended "etc." at the conclusion of enumerating such data.

--- a/content/memos/doubao-starts-tracking-users-behavioral-data.md
+++ b/content/memos/doubao-starts-tracking-users-behavioral-data.md
@@ -4,6 +4,7 @@ title: Doubao starts tracking users behavioral data
 service: Copy.AI
 terms_types: ["Privacy Policy"]
 dates: ["2023-12-28"]
+author: Peijun Hu
 ---
 
 Doubao [added](https://github.com/OpenTermsArchive/GenAI-versions/commit/c799b6fce756dfc6894a2537db01d71d91a4f776) personalized recommendations for prompts and chatbots and personal data collection requirements, with an opt-out option.

--- a/content/memos/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.fr.md
+++ b/content/memos/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.fr.md
@@ -5,6 +5,7 @@ service: "Facebook"
 terms_types: ["Community Guidelines"]
 dates: ["2022-04-28"]
 aliases: /fr/etudes-de-cas/facebook-interdit-aux-etats-de-nier-lusage-de-la-force-lors-dune-invasion/
+author: Mathilde Saliou
 ---
 
 Facebook <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/b315d25#diff-57f4f166af0a7f6e4fc8f63a103c74f5a8d47754238aad621db0eebdf4048df4R24">a ajouté</a> une interdiction à ses règles de prévention de manipulation de sa plateforme : l’entreprise indique ne plus autoriser « les gouvernements qui ont mis en place un blocage durable des médias sociaux à utiliser leurs agences, ambassades et services officiels pour nier tout recours à la force ou tout évènement violent dans le cadre d’une attaque contre l’intégrité territoriale d’un autre État ». Facebook ajoute qu’il pourra demander des informations ou du contexte supplémentaire pour s’assurer du respect de cette nouvelle règle, ainsi que pour d’autres formes de manipulation déjà encadrées (astroturfing, ingérence gouvernementale ou étrangère).

--- a/content/memos/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.md
+++ b/content/memos/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion.md
@@ -7,6 +7,7 @@ dates: ["2022-04-28"]
 aliases:
   - /case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion/
   - /en/case-studies/facebook-bans-states-from-denying-the-use-of-violence-in-an-invasion/
+author: Mathilde Saliou
 ---
 
 Facebook <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/b315d25#diff-57f4f166af0a7f6e4fc8f63a103c74f5a8d47754238aad621db0eebdf4048df4R24">will no longer allow</a> "governments that have instituted sustained blocks of social media to use their official departments, agencies, and embassies to deny the use of force or violent events in the context of an attack against the territorial integrity of another state." Facebook adds that it may require additional information or context to ensure compliance with this new rule, as well as for other forms of manipulation already covered (astroturfing, government or foreign interference).

--- a/content/memos/facebook-goes-back-in-time.fr.md
+++ b/content/memos/facebook-goes-back-in-time.fr.md
@@ -4,6 +4,7 @@ title: "Facebook remonte le temps"
 service: "Facebook"
 terms_types: ["Terms of Service"]
 dates: ["2022-06-14"]
+author: Mathilde Saliou
 ---
 
 Le 14 juin, Facebook a [antidaté](https://github.com/OpenTermsArchive/france-elections-versions/commit/430f4a67045323a8c862808eb046b7ea8616842b) la date de dernière mise à jour de ses conditions d’utilisation : plutôt que le 4 janvier 2022, date à laquelle l’entreprise Facebook a été renommée Meta, il est désormais indiqué que la dernière révision remonte au… 20 décembre 2020, plus d'un an plus tôt !

--- a/content/memos/facebook-goes-back-in-time.md
+++ b/content/memos/facebook-goes-back-in-time.md
@@ -4,6 +4,7 @@ title: "Facebook goes back in time"
 service: "Facebook"
 terms_types: ["Terms of Service"]
 dates: ["2022-06-14"]
+author: Mathilde Saliou
 ---
 
 On June 14, Facebook [backdated](https://github.com/OpenTermsArchive/france-elections-versions/commit/430f4a67045323a8c862808eb046b7ea8616842b) the last update of its terms of use: rather than 4 January 2022, when Facebook was renamed Meta, it now states that the last revision goes back to... December 20, 2020, over one year earlier!

--- a/content/memos/google-integrates-its-generative-ai-services-terms-into-their-standard-terms.md
+++ b/content/memos/google-integrates-its-generative-ai-services-terms-into-their-standard-terms.md
@@ -4,6 +4,7 @@ title: Google integrates its Generative AI Services terms into their standard te
 service: Google
 terms_types: ["Terms of Service"]
 dates: ["2024-05-22"]
+author: Clément Biron
 ---
 
 Google [integrated](https://github.com/OpenTermsArchive/GenAI-versions/commit/5dc544475a9dd326f2ce7f107a89cb94c5f14cb6) all provisions of its Generative AI Additional Terms of Service into their main Terms of Service. Starting on 22 May 2024, the additional terms “no longer apply, unless you’re a business partner with a signed agreement that references these terms.”

--- a/content/memos/instagram-adds-a-posting-ban-to-protect-copyright.fr.md
+++ b/content/memos/instagram-adds-a-posting-ban-to-protect-copyright.fr.md
@@ -5,6 +5,7 @@ service: "Instagram"
 terms_types: ["Community Guidelines"]
 dates: ["2022-03-28"]
 aliases: /fr/etudes-de-cas/instagram-interdit-le-contenu-qui-facilite-linfraction-des-droits-dauteur/
+author: Mathilde Saliou
 ---
 
 La partie « propriété intellectuelle » des règles de communauté d’Instagram a été [modifiée](https://github.com/OpenTermsArchive/france-elections-versions/commit/1be4b836e3012344558b60d8f9f871bc42cfa4ca?short_path=c108c01#diff-c108c013f0b8769389f20259465cb81324e805f4334bcda6931344e16f999441) le 28 mars pour interdire la publication de contenu qui « facilite l’infraction des droits d’auteur par le biais d’appareils ou services non autorisés ». Le texte présente une liste de cas dans lesquels l’internaute risquerait d’enfreindre les droits d’auteurs d’un tiers ou, ajout du jour, « de faciliter cette infraction », même s’il n’en avait pas l’intention. Derrière les cas précédemment listés, parmi lesquels « vous avez acheté ou téléchargé le contenu » ou « vous avez vu d’autres personnes publier le même contenu », Instagram ajoute que l’utilisateur risque d’enfreindre les droits d’auteurs s’il ou elle « utilise un appareil ou service de streaming non autorisé (exemples : une application ou un service “débridés” ou “chargés”) ».

--- a/content/memos/instagram-adds-a-posting-ban-to-protect-copyright.md
+++ b/content/memos/instagram-adds-a-posting-ban-to-protect-copyright.md
@@ -7,6 +7,7 @@ dates: ["2022-03-28"]
 aliases:
   - /case-studies/instagram-adds-a-posting-ban-to-protect-copyright/
   - /en/case-studies/instagram-adds-a-posting-ban-to-protect-copyright/
+author: Mathilde Saliou
 ---
 
 On March 28, Instagram [updated](https://github.com/OpenTermsArchive/france-elections-versions/commit/1be4b836e3012344558b60d8f9f871bc42cfa4ca?short_path=c108c01#diff-c108c013f0b8769389f20259465cb81324e805f4334bcda6931344e16f999441) its intellectual property community rules, prohibiting the posting of content that “facilitates copyright infringement through unauthorized devices or services.” The text presents a list of cases in which users would risk infringing the copyright of a third party or even merely “facilitating” such infringement, even if they did not intend to do so. After the previously listed cases, which include “you purchased or downloaded the content” or “you saw others post the same content,” Instagram adds that users risk infringing copyright if they “use an unauthorized streaming device or service (examples: a ‘jailbroken’ or ‘loaded’ app or service).”

--- a/content/memos/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.fr.md
+++ b/content/memos/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.fr.md
@@ -5,6 +5,7 @@ service: "Instagram"
 terms_types: ["Community Guidelines","Terms of use","Privacy Policy"]
 dates: ["2021-11-03", "2021-11-10", "2021-11-16"]
 aliases: /fr/etudes-de-cas/instagram-bloque-la-recuperation-de-donnees-et-precise-les-informations-quelle-recupere/
+author: Thomas Reboul
 ---
 
 En novembre 2021, Instagram a procédé à plusieurs mises à jour de ses <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/9998cb21b69a222540491a81dd05be19a9785891">règles de communauté</a>, de ses <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/9aaf5dbfc3b34d45d640b0c7f96dce3598c7bcd2">conditions d’utilisation</a> et de sa <a  target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/927ceba3865d79cd1b123d9f4b9928b8e997070c">politique de vie privée</a>. Parmi les évolutions notables, la plateforme interdit explicitement la vente ou l’échange de « substances non médicales ou pharmaceutiques ». Elle indique supprimer toutes les publications promouvant ce type de produit, que ce soit pour les vendre ou pour en indiquer une consommation personnelle, sauf dans un contexte de guérison.

--- a/content/memos/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.md
+++ b/content/memos/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves.md
@@ -7,6 +7,7 @@ dates: ["2021-11-03", "2021-11-10", "2021-11-16"]
 aliases:
   - /case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves/
   - /en/case-studies/instagram-blocks-data-retrieval-and-clarifies-what-information-it-retrieves/
+author: Thomas Reboul
 ---
 
 In November 2021, Instagram made several updates to its <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/9998cb21b69a222540491a81dd05be19a9785891">community rules</a>, its <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/9aaf5dbfc3b34d45d640b0c7f96dce3598c7bcd2">terms of use</a> and its <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/927ceba3865d79cd1b123d9f4b9928b8e997070c">privacy policy</a>. Among the notable developments, the platform explicitly prohibits the sale or exchange of "non-medical or pharmaceutical substances." It says it will remove all posts promoting such products, either for sale or to indicate personal consumption, except in a healing context.

--- a/content/memos/instagram-commits-to-informing-in-case-of-content-removal.fr.md
+++ b/content/memos/instagram-commits-to-informing-in-case-of-content-removal.fr.md
@@ -5,6 +5,7 @@ service: "Instagram"
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
 aliases: /fr/etudes-de-cas/instagram-sengage-a-informer-en-cas-de-suppression-de-contenu/
+author: Mathilde Saliou
 ---
 
 Progrès en demi-teinte : Instagram [annonce désormais](https://github.com/OpenTermsArchive/france-versions/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a?short_path=311682c?short_path=311682c) que « dans certains cas où nous supprimons du contenu, nous vous en informerions et vous expliquerons les options à votre disposition pour demander un réexamen ». Une telle décision pourrait avoir un impact pour des comptes comme ceux des 14 influenceuses féministes françaises qui ont assigné le réseau social en justice [l’an dernier](https://www.ouest-france.fr/high-tech/instagram/instagram-14-feministes-assignent-facebook-en-justice-apres-la-censure-de-leurs-contenus-7181707). Celles-ci accusaient Instagram de supprimer des publications ou des comptes sans donner d’explications claires sur les raisons de ces suppressions, ni d’outils pour se défendre.  Les conditions d’utilisation ne précisent toutefois pas les cas dans lesquels Instagram fournira les informations annoncées. Elles avertissent aussi qu’aucune information ne sera donnée si l’internaute enfreint « gravement ou à maintes reprises les conditions », entre autres situations que Meta jugera particulièrement graves.

--- a/content/memos/instagram-commits-to-informing-in-case-of-content-removal.md
+++ b/content/memos/instagram-commits-to-informing-in-case-of-content-removal.md
@@ -7,6 +7,7 @@ dates: ["2022-02-20"]
 aliases:
   - /case-studies/instagram-commits-to-informing-in-case-of-content-removal/
   - /en/case-studies/instagram-commits-to-informing-in-case-of-content-removal/
+author: Mathilde Saliou
 ---
 
 Some progress: Instagram now [announces](https://github.com/OpenTermsArchive/versions-france/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a?short_path=311682c#) that in some cases where it removes content, the firm will notify the user and explain their options for requesting a review. Such a decision could have an impact on accounts like those of the 14 French feminist influencers who [took the social network to court](https://www.ouest-france.fr/high-tech/instagram/instagram-14-feministes-assignent-facebook-en-justice-apres-la-censure-de-leurs-contenus-7181707) last year. They accused Instagram of deleting posts or accounts without giving clear explanations of the reasons for these deletions, or tools to defend themselves. The terms of use do not, however, specify the cases in which Instagram will provide the announced information. They also warn that no information will be given if the user gravely or repeatedly violates the terms, among other situations that Meta will consider particularly serious.

--- a/content/memos/instagram-cross-references-its-data-with-user-experience-surveys.fr.md
+++ b/content/memos/instagram-cross-references-its-data-with-user-experience-surveys.fr.md
@@ -4,6 +4,7 @@ title: Instagram croise ses données avec des sondages d’expérience utilisate
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 Instagram détaille un peu plus l’usage qu’elle fait des données utilisateurs. Alors qu’elle indiquait simplement utiliser « les informations à notre disposition afin de développer, tester et améliorer notre Service », Instagram [ajoute désormais](https://github.com/OpenTermsArchive/france-versions/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a#diff-311682cd6d20df952901439aefad05738f09eb8ca4f505b3af21ce20ff70f23aR37) : « Cela inclut d’analyser les données que nous avons concernant nos utilisateurs et de comprendre comment les personnes utilisent nos Services, par exemple, en effectuant des sondages et des tests. »

--- a/content/memos/instagram-cross-references-its-data-with-user-experience-surveys.md
+++ b/content/memos/instagram-cross-references-its-data-with-user-experience-surveys.md
@@ -4,6 +4,7 @@ title: Instagram cross-references its data with user experience surveys
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 Instagram goes into [more detail](https://github.com/OpenTermsArchive/versions-france/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a#diff-311682cd6d20df952901439aefad05738f09eb8ca4f505b3af21ce20ff70f23aR37) about its use of user data. While it used to simply state that it uses the information available to us to develop, test and improve our Service, Instagram now adds that it includes “analysing the data we have about our users and understanding how people use our Services, for example by conducting surveys and testing and troubleshooting new features”.

--- a/content/memos/instagram-restricts-its-ability-to-delete-content.fr.md
+++ b/content/memos/instagram-restricts-its-ability-to-delete-content.fr.md
@@ -4,6 +4,7 @@ title: Instagram restreint sa capacité à supprimer du contenu
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 Jusqu’ici, Instagram déclarait supprimer du contenu ou des informations partagées sur sa plateforme si elle estime que ces dernières violent ses conditions d’utilisation « ou si la loi nous y autorise ou nous y oblige ». Le document [indique aujourd’hui](https://github.com/OpenTermsArchive/france-versions/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a#diff-311682cd6d20df952901439aefad05738f09eb8ca4f505b3af21ce20ff70f23aR109) qu’Instagram supprimera des contenus au nom de la loi du pays concerné seulement si cette dernière l’y « oblige ».

--- a/content/memos/instagram-restricts-its-ability-to-delete-content.md
+++ b/content/memos/instagram-restricts-its-ability-to-delete-content.md
@@ -4,6 +4,7 @@ title: Instagram restricts its ability to delete content
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 Until now, Instagram said it would remove information shared on its platform if it believed the content to violate its terms of use, or if the firm was permitted or required to do so by law. The document [now states](https://github.com/OpenTermsArchive/versions-france/commit/b8b71e45d56728242ce7c5da3e8b7ef790eec57a#diff-311682cd6d20df952901439aefad05738f09eb8ca4f505b3af21ce20ff70f23aR109) that Instagram will only remove content on behalf of the law of the country concerned if it is "required" to do so.

--- a/content/memos/instagram-takes-significantly-more-responsibility-in-case-of-an-incident.fr.md
+++ b/content/memos/instagram-takes-significantly-more-responsibility-in-case-of-an-incident.fr.md
@@ -4,6 +4,7 @@ title: Instagram prend significativement plus ses responsabilités en cas d'inci
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 Dans la version précédente, le réseau social déclarait fournir son service « en l’état », dans l’incapacité de « garantir son fonctionnement idéal et sûr en permanence » et déclinait (tout en majuscule) « toute garantie explicite ou implicite », notamment de « qualité marchande, d’adéquation à un usage particulier, de titre et d’absence de contrefaçon ». Elle déclarait ne pas contrôler les propos et publications « des tiers », « ni les vôtres » et avoir une responsabilité « limitée autant que la loi le permet » en cas d’incident.

--- a/content/memos/instagram-takes-significantly-more-responsibility-in-case-of-an-incident.md
+++ b/content/memos/instagram-takes-significantly-more-responsibility-in-case-of-an-incident.md
@@ -4,6 +4,7 @@ title: Instagram takes significantly more responsibility in case of an incident
 service: Instagram
 terms_types: ["Terms of Service"]
 dates: ["2022-02-20"]
+author: Mathilde Saliou
 ---
 
 In the previous version of its Terms of Services, the social network stated that it provided its service as it is, unable to guarantee its ideal and safe operation at all times. Instagram disclaimed (in all caps) any express or implied warranties, including merchantability, fitness for a particular purpose, title and non-infringement, and stated that it did not control the words and publications of third parties, nor those of the user, and that its liability was limited to the extent permitted by law in the event of an incident.

--- a/content/memos/linkedins-community-rules-are-not-translated-anymore.fr.md
+++ b/content/memos/linkedins-community-rules-are-not-translated-anymore.fr.md
@@ -4,6 +4,7 @@ title: "Les règles de communauté de LinkedIn seulement accessibles en anglais"
 service: "LinkedIn"
 terms_types: ["Community Guidelines"]
 dates: ["2022-05-20"]
+author: Mathilde Saliou
 ---
 
 Depuis le 20 mai, Open Terms Archive constate que les règles de communauté de LinkedIn ne sont plus accessibles en français — ni en aucune langue autre que l'anglais. La page renvoie systématiquement vers la version anglaise des [Community Policies](https://www.linkedin.com/legal/professional-community-policies).

--- a/content/memos/linkedins-community-rules-are-not-translated-anymore.md
+++ b/content/memos/linkedins-community-rules-are-not-translated-anymore.md
@@ -4,6 +4,7 @@ title: "LinkedIn's community rules are not translated anymore"
 service: "LinkedIn"
 terms_types: ["Community Guidelines"]
 dates: ["2022-05-20"]
+author: Mathilde Saliou
 ---
 
 Since May 20, Open Terms Archive notes that LinkedIn's Community rules are no longer accessible in French —or any other language. Those pages seem to have vanished: even when manually changing language, the page redirects to the English version of the [Community Guidelines](https://www.linkedin.com/legal/professional-community-policies).

--- a/content/memos/meta-adds-anti-suicide-action.fr.md
+++ b/content/memos/meta-adds-anti-suicide-action.fr.md
@@ -4,6 +4,7 @@ title: "Meta ajoute des actions de lutte contre le suicide"
 service: "Facebook"
 terms_types: ["Community Guidelines - Self-harm"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 Facebook a [ajouté](https://github.com/OpenTermsArchive/france-elections-versions/commit/242048233610ece2729d0b39047dcd5adeb21e25) le 13 juin à la cible des personnes recevant « des ressources » les utilisateurs qui publient « des déclarations ou des références vagues, potentiellement suicidaires (y compris des memes ou des images de photothèque sur l’humeur triste ou la dépression) dans un contexte de suicide ou d’automutilation ». Meta a [modifié](https://github.com/OpenTermsArchive/france-elections-versions/commit/82cc72a102fc78107e7094f995e07b9e4364431d) les mêmes éléments sur Instagram.

--- a/content/memos/meta-adds-anti-suicide-action.md
+++ b/content/memos/meta-adds-anti-suicide-action.md
@@ -4,6 +4,7 @@ title: "Meta adds anti-suicide action"
 service: "Facebook"
 terms_types: ["Community Guidelines - Self-harm"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 On June 13, Facebook [expanded](https://github.com/OpenTermsArchive/france-elections-versions/commit/242048233610ece2729d0b39047dcd5adeb21e25) the target group of users receiving “help resources” to those who post “vague, potentially suicidal statements or references (including memes or photo library images about sad moods or depression) in the context of suicide or self-harm”. Meta [changed](https://github.com/OpenTermsArchive/france-elections-versions/commit/82cc72a102fc78107e7094f995e07b9e4364431d) the same elements on Instagram.

--- a/content/memos/meta-allows-more-nudity-in-a-medical-context.fr.md
+++ b/content/memos/meta-allows-more-nudity-in-a-medical-context.fr.md
@@ -4,6 +4,7 @@ title: "Meta autorise plus de nudité dans un contexte médical"
 service: "Facebook"
 terms_types: ["Community Guidelines – Adult Nudity"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 Facebook [précise](https://github.com/OpenTermsArchive/france-elections-versions/commit/200fae809ed553d6882bef3659b4544fac37e322#diff-f5b2499012804c371ee8d35d8a109e0b7a91f6a2d6d7736ab9857bfd331dbf68R23-R26) depuis le 13 juin que les publications de parties génitales visibles ou de mamelons de femmes découverts sont acceptées si la publication relève d’un contexte médical ou lié à la santé. Meta a modifié les mêmes éléments dans les règles de communauté d’Instagram.

--- a/content/memos/meta-allows-more-nudity-in-a-medical-context.md
+++ b/content/memos/meta-allows-more-nudity-in-a-medical-context.md
@@ -4,6 +4,7 @@ title: "Meta allows more nudity in a medical context"
 service: "Facebook"
 terms_types: ["Community Guidelines – Adult Nudity"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 Since June 13, Facebook [specifies](https://github.com/OpenTermsArchive/france-elections-versions/commit/200fae809ed553d6882bef3659b4544fac37e322#diff-f5b2499012804c371ee8d35d8a109e0b7a91f6a2d6d7736ab9857bfd331dbf68R23-R26) that posts with visible genitals or stimulated female nipples are acceptable if the post is about a medical or health-related issue. Meta changed the same elements in the Instagram community rules.

--- a/content/memos/meta-expands-reach-against-child-exploitation.fr.md
+++ b/content/memos/meta-expands-reach-against-child-exploitation.fr.md
@@ -4,6 +4,7 @@ title: "Meta élargit ses zones d’action face à l’exploitation d’enfants"
 service: "Facebook"
 terms_types: ["Community Guidelines – Child Exploitation"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 La partie relative à l’exploitation d’enfants [s’élargit](https://github.com/OpenTermsArchive/france-elections-versions/commit/0396436542fa7ef8dd8ae4dd02ff0ed5500e08a2) pour couvrir non seulement les publications d’exploitation de mineurs, mais aussi « toute activité » relative à ce type d’actes. Meta a modifié les mêmes éléments dans les règles de communauté de Facebook et d’Instagram.

--- a/content/memos/meta-expands-reach-against-child-exploitation.md
+++ b/content/memos/meta-expands-reach-against-child-exploitation.md
@@ -4,6 +4,7 @@ title: "Meta expands reach against child exploitation"
 service: "Facebook"
 terms_types: ["Community Guidelines – Child Exploitation"]
 dates: ["2022-06-13"]
+author: Mathilde Saliou
 ---
 
 The section on child exploitation for both Facebook and Instagram [expanded](https://github.com/OpenTermsArchive/france-elections-versions/commit/0396436542fa7ef8dd8ae4dd02ff0ed5500e08a2) to cover not only publications that exploit minors, but also “any activity” related to such acts.

--- a/content/memos/meta-tests-notification-of-changes-for-its-terms.fr.md
+++ b/content/memos/meta-tests-notification-of-changes-for-its-terms.fr.md
@@ -4,6 +4,7 @@ title: "Meta teste la notification d’évolutions de ses conditions d’utilisa
 service: "Facebook"
 terms_types: ["Terms of Service"]
 dates: ["2022-05-17","2022-05-25","2022-05-26"]
+author: Mathilde Saliou
 ---
 
 Beaucoup de mouvements discrets chez Meta ces derniers temps : l’entreprise a d’abord [ajouté](https://github.com/OpenTermsArchive/france-elections-versions/commit/c57c282d0b75a479da787f7a2e8d1f9ee333d72a) le 17 mai une mention annonçant qu’elle modifierait les conditions d'utilisation de Facebook le 26 juillet, sans que le lien censé permettre de consulter les modifications à venir ne fonctionne. Le 25 mai, la mention a été [effacée](https://github.com/OpenTermsArchive/france-elections-versions/commit/a1be6b0ee835d067402513d24586e7216acf6008). Le lendemain, une nouvelle phrase apparaît, cette fois-ci dans les politiques de confidentialité d’Instagram et Facebook, déclarant « Nous avons mis à jour notre politique. » Du côté de Facebook, le lien renvoie vers [une page](https://www.facebook.com/privacy/policy) qui indique que les modifications prendront effet… le 27 juillet 2022. Chez Instagram, [le lien](https://help.instagram.com/privacy/policy) menant vers les nouvelles politiques de confidentialité ne fonctionne toujours pas.

--- a/content/memos/meta-tests-notification-of-changes-for-its-terms.md
+++ b/content/memos/meta-tests-notification-of-changes-for-its-terms.md
@@ -4,6 +4,7 @@ title: "Meta tests notification of changes for its terms"
 service: "Facebook"
 terms_types: ["Terms of Service"]
 dates: ["2022-05-17","2022-05-25","2022-05-26"]
+author: Mathilde Saliou
 ---
 
 Meta has been busy lately: the company first [added](https://github.com/OpenTermsArchive/france-elections-versions/commit/c57c282d0b75a479da787f7a2e8d1f9ee333d72a) a notice on May 17 announcing that it would change its Terms of Services on July 26. However, the link that was supposed to show the upcoming changes did not work. On May 25, the mention [disappeared](https://github.com/OpenTermsArchive/france-elections-versions/commit/a1be6b0ee835d067402513d24586e7216acf6008). The day after, a new sentence appeared in both Instagram and Facebook's Privacy policies, stating “We have updated our policy.” On Facebook, the link leads to [a page](https://www.facebook.com/privacy/policy) mentioning an effect date of July 27, 2022. On Instagram, the [link](https://help.instagram.com/privacy/policy) to the new Privacy policies still does not work.

--- a/content/memos/midjourney-ceases-free-trials-as-it-unveils-subscription-plans.md
+++ b/content/memos/midjourney-ceases-free-trials-as-it-unveils-subscription-plans.md
@@ -4,6 +4,7 @@ title: Midjourney ceases free trials as it unveils subscription plans
 service: Midjourney
 terms_types: ["Terms of Service"]
 dates: ["2023-12-21"]
+author: Brice Bai
 ---
 
 Midjourney [ceased](https://github.com/OpenTermsArchive/GenAI-versions/commit/e2662337073ce704cbf2dd91457dc7d89ae59e36?diff=split&w=0) to refer to the entitlements of unpaid members to the assets they create. Indeed, Midjourney [stopped](https://help.midjourney.com/en/articles/8150088-is-there-a-free-trial) offering free trials. They also extended the obligation to subscribe for a Pro or Mega plan for employees of companies with over 1M$ in revenue.

--- a/content/memos/midjourney-strengthens-policies-on-intellectual-property-infringements.md
+++ b/content/memos/midjourney-strengthens-policies-on-intellectual-property-infringements.md
@@ -4,6 +4,7 @@ title: Midjourney strengthens policies on intellectual property infringements
 service: Midjourney
 terms_types: ["Terms of Service"]
 dates: ["2023-12-23"]
+author: Brice Bai
 ---
 
 Midjourney introduced an explicit [prohibition](https://github.com/OpenTermsArchive/GenAI-versions/commit/2cb30a2b4b338a4dffbeab9add8262cec78a3062) regarding the infringement of others’ intellectual property rights in its conditions for service availability and quality, mentioning the possibility of legal action and permanent ban from the service.

--- a/content/memos/mistral-ai-retains-api-prompts-and-outputs-for-30-days.md
+++ b/content/memos/mistral-ai-retains-api-prompts-and-outputs-for-30-days.md
@@ -4,6 +4,7 @@ title: Mistral AI retains API prompts and outputs for 30 days
 service: Mistral AI
 terms_types: ["Developer Terms"]
 dates: ["2024-05-22"]
+author: Clément Biron
 ---
 
 Mistral AI [started](https://github.com/OpenTermsArchive/GenAI-versions/commit/67aef6919c6ea9094f5c3d2a909cfa975fe6dbd5) retaining prompts and outputs of API users for 30 days to “monitor abuse”.

--- a/content/memos/murf-claims-publicity-rights-over-clients-names.md
+++ b/content/memos/murf-claims-publicity-rights-over-clients-names.md
@@ -4,6 +4,7 @@ title: Murf claims publicity rights over clients names
 service: Murf
 terms_types: ["Terms of Service"]
 dates: ["2024-01-16"]
+author: Brice Bai
 ---
 
 Murf [added](https://github.com/OpenTermsArchive/GenAI-versions/commit/a9052d3dad068c9824c78a254a4e34cf45a1558a) a provision establishing that their users and their organisations grant Murf the right to identify them in commercial communications and case studies as Murf’s customers.

--- a/content/memos/murf-commits-to-comply-with-the-eu-uk-and-swiss-us-data-privacy-framework.md
+++ b/content/memos/murf-commits-to-comply-with-the-eu-uk-and-swiss-us-data-privacy-framework.md
@@ -4,6 +4,7 @@ title: Murf commits to comply with the EU-, UK- and Swiss-U.S. Data Privacy Fram
 service: Murf
 terms_types: ["Privacy Policy"]
 dates: ["2023-11-03"]
+author: Brice Bai
 ---
 
 Murf [committed](https://github.com/OpenTermsArchive/GenAI-versions/commit/4adb6986e2e69a76fd265dc19597a3bd19395354) to comply with the EU-U.S. Data Protection Framework (DPF), the UK Extension of the EU-U.S. DPF, and the Swiss-U.S. DPF.

--- a/content/memos/murf-streamlines-licensing-through-identified-use-cases.md
+++ b/content/memos/murf-streamlines-licensing-through-identified-use-cases.md
@@ -4,6 +4,7 @@ title: Murf streamlines licensing through identified use cases
 service: Murf
 terms_types: ["Terms of Service"]
 dates: ["2023-11-03"]
+author: Brice Bai
 ---
 
 First, Murf [ceased](https://github.com/OpenTermsArchive/GenAI-versions/commit/de437963aac5969e1af7bff0fb48a2aa890ad188) to grant a license for the use and display of their logo/marks only to identify that the Generated Content originates from Murf.

--- a/content/memos/new-microsoft-tracker-at-tik-tok.fr.md
+++ b/content/memos/new-microsoft-tracker-at-tik-tok.fr.md
@@ -4,6 +4,7 @@ title: Nouveau traceur Microsoft chez TikTok
 service: TikTok
 terms_types: ["Trackers Policy"]
 dates: ["2022-03-09"]
+author: Mathilde Saliou
 ---
 
 Évolution discrète dans la politique de TikTok relative aux cookies : le média social ajoute [Bing Pixel](https://github.com/OpenTermsArchive/france-versions/commit/b5f7e56ccfe38a03d9fcdeae9ce80e897c8f7333?short_path=d187ffa?short_path=d187ffa#diff-d187ffa99dddfb4f2bda567ea1fa79e37ab477ff82ddedc5dad3f18394d2f981) à ses prestataires d’analyse de données analytiques et marketing. Le service de Microsoft rejoint Linkedin Insight Tag (LinkedIn est aussi propriété de Microsoft), Google Analytics et Google Ads, Apps Flyer et Facebook Pixel.

--- a/content/memos/new-microsoft-tracker-at-tik-tok.md
+++ b/content/memos/new-microsoft-tracker-at-tik-tok.md
@@ -4,6 +4,7 @@ title: New Microsoft tracker at TikTok
 service: TikTok
 terms_types: ["Trackers Policy"]
 dates: ["2022-03-09"]
+author: Mathilde Saliou
 ---
 
 TikTok's cookie policy has quietly evolved, with the social media company [adding](https://github.com/OpenTermsArchive/versions-france/commit/b5f7e56ccfe38a03d9fcdeae9ce80e897c8f7333?short_path=d187ffa#diff-d187ffa99dddfb4f2bda567ea1fa79e37ab477ff82ddedc5dad3f18394d2f981) Bing Pixel to its analytics and marketing data providers. The Microsoft service joins Linkedin Insight Tag (LinkedIn is also owned by Microsoft), Google Analytics and Google Ads, AppsFlyer and Facebook Pixel.

--- a/content/memos/openai-delays-the-date-of-entry-into-force-of-their-new-non-european-terms-of-service.md
+++ b/content/memos/openai-delays-the-date-of-entry-into-force-of-their-new-non-european-terms-of-service.md
@@ -4,6 +4,7 @@ title: OpenAI delays the date of entry into force of their new non-European term
 service: OpenAI
 terms_types: ["Privacy Policy"]
 dates: ["2023-12-03"]
+author: Brice Bai
 ---
 
 OpenAI [postponed](https://github.com/OpenTermsArchive/GenAI-versions/commit/417bd95e82655cc88182e8929eb199fb86ed4edf) the effective date of its new non-European terms of service from December 14 2023 to January 31 2024.

--- a/content/memos/openai-enables-transfer-of-control-of-non-european-accounts-to-their-employer.md
+++ b/content/memos/openai-enables-transfer-of-control-of-non-european-accounts-to-their-employer.md
@@ -4,6 +4,7 @@ title: OpenAI enables transfer of control of non-European accounts to their empl
 service: OpenAI
 terms_types: ["Privacy Policy"]
 dates: ["2023-11-13"]
+author: Brice Bai
 ---
 
 OpenAI [stated](https://github.com/OpenTermsArchive/GenAI-versions/commit/2156cb964370ce4a838bc7f03b57513edf07d47e#diff-41ba34d83f6a6973f8baa1a83e44c28a8bfc58b4d5e152865c765bf95e941cc0R92) that starting on December 14, 2023, they would notify organisations (e.g. employers) about individual accounts created with organisational email addresses. This notification allows to transfer these individual accounts to business accounts, under which organisations have access to all inputs and outputs of their generative AI services and control over the individual accounts.

--- a/content/memos/openai-introduces-acceptable-uses-for-api-and-custom-gpts.md
+++ b/content/memos/openai-introduces-acceptable-uses-for-api-and-custom-gpts.md
@@ -4,6 +4,7 @@ title: OpenAI introduces acceptable uses for API and custom GPTs
 service: OpenAI
 terms_types: ["Acceptable Use Policy"]
 dates: ["2024-01-10"]
+author: Brice Bai
 ---
 
 OpenAI re–[categorised](https://github.com/OpenTermsArchive/GenAI-versions/commit/8cf83dcc3d59265f901db93f5408ea98876dabc3) their Acceptable Use Policy into three distinct lists of prohibitions.

--- a/content/memos/openai-specifies-further-plugin-exports-rules.md
+++ b/content/memos/openai-specifies-further-plugin-exports-rules.md
@@ -4,6 +4,7 @@ title: OpenAI specifies further plugin exports rules
 service: OpenAI
 terms_types: ["Developers Terms"]
 dates: ["2024-01-10"]
+author: Brice Bai
 ---
 
 OpenAI [specified](https://github.com/OpenTermsArchive/GenAI-versions/commit/30f1df7d18676c57a0ae1c43c3ccdfc264535cb3) that, as far as European (EEA and Swiss) developers were concerned, their Agreement is with OpenAI Ireland Ltd. OpenAI stopped acting as a separate controller of personal data, and developers now have to present a privacy notice to their users prior to processing their data.

--- a/content/memos/openai-tightens-security-and-adds-appeal-mechanism-for-suspended-accounts.md
+++ b/content/memos/openai-tightens-security-and-adds-appeal-mechanism-for-suspended-accounts.md
@@ -4,6 +4,7 @@ title: OpenAI tightens security and adds appeal mechanism for suspended accounts
 service: OpenAI
 terms_types: ["Terms of Service"]
 dates: ["2023-11-14"]
+author: Brice Bai
 ---
 
 OpenAI [prohibited](https://github.com/OpenTermsArchive/GenAI-versions/commit/d9d49b2d5e5354590a50a181cb3034b888f7d03d) the modification, copying or leasing of its services as well as the circumvention of their services’ security measures. It also limited its liability by requiring users to warrant rights in their inputs and by clarifying that the output shall not be seen as factual information or as OpenAI’s opinion.

--- a/content/memos/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.fr.md
+++ b/content/memos/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.fr.md
@@ -5,6 +5,7 @@ service: "Pinterest"
 terms_types: ["Privacy Policy"]
 dates: ["2020-07-21"]
 aliases: /fr/etudes-de-cas/pinterest-retire-les-mentions-du-privacy-shield-sans-mettre-a-jour-la-date-de-modification/
+author: Elsa Trujilo
 ---
 
 Pinterest a <a target="_blank" rel="noopener" href="https://github.com/ambanum/CGUs-data/commit/a53e891ba">supprimé</a> une longue explication de ses modalités de traitement des données, qu’elle indiquait réaliser en vertu du Privacy Shield alors en place entre l’Union Européenne aux États-Unis. Jusque-là, l’entreprise s’engageait à résoudre toute plainte relative au traitement des données personnelles et à vérifier autant que possible que ses partenaires étaient eux aussi en conformité avec le Privacy Shield. Le 21 juillet 2020, ce passage a été remplacé par une simple phrase indiquant que les données personnelles de l’espace économique européen pourraient être traitées en dehors, sans engagement de gestion des plaintes. La plateforme n’a pas indiqué, dans son « résumé des changements récents » en tête du document, qu’elle avait réalisé de tels changements.

--- a/content/memos/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.md
+++ b/content/memos/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date.md
@@ -7,6 +7,7 @@ dates: ["2020-07-21"]
 aliases:
   - /case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date/
   - /en/case-studies/pinterest-removes-privacy-shield-notice-without-updating-its-modification-date/
+author: Elsa Trujilo
 ---
 
 Pinterest has <a target="_blank" rel="noopener" href="https://github.com/ambanum/CGUs-data/commit/a53e891ba">removed</a> a lengthy explanation of its data processing arrangements, which it said it was carrying out under the Privacy Shield then in place between the European Union and the United States. Until then, the company was committed to resolving any complaints about personal data processing and verifying as much as possible that its partners were also in compliance with the Privacy Shield. On July 21, 2020, this part was replaced by a simple sentence stating that personal data from the European Economic Area could be processed outside of it, without a commitment to manage complaints. The platform did not indicate in its "summary of recent changes" at the top of the document that it had made any such changes.

--- a/content/memos/protonmail-clarifies-its-privacy-policies.fr.md
+++ b/content/memos/protonmail-clarifies-its-privacy-policies.fr.md
@@ -1,10 +1,11 @@
 ---
-html_description: "Le 6 septembre 2021, ProtonMail a modifié ses politiques de confidentialité de sorte à clarifier les effets des lois suisses..."
+html_description: "Le 6 septembre 2021, ProtonMail a modifié ses politiques de confidentialité de sorte à clarifier les effets des lois suisses."
 title: "Protonmail clarifie ses politiques de confidentialité"
 service: "Protonmail"
 terms_types: ["Privacy Policy"]
 dates: ["2021-09-06"]
 aliases: /fr/etudes-de-cas/protonmail-clarifie-ses-politiques-de-confidentialite/
+author: Elsa Trujilo
 ---
 
 Le 6 septembre 2021, ProtonMail a <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/510c7d65e4254e1d53221b139d7e25bb2b990510">modifié</a> ses politiques de confidentialité de sorte à clarifier les effets des lois suisses (où l’entreprise est installée) sur le traitement des données des utilisateurs. Ainsi, bien que la société déclare offrir un service de courriel particulièrement sécurisé, elle peut se retrouver « forcée de partager l’adresse IP » de ses utilisateurs avec les forces de l’ordre dans le cadre d’enquêtes criminelles.

--- a/content/memos/protonmail-clarifies-its-privacy-policies.md
+++ b/content/memos/protonmail-clarifies-its-privacy-policies.md
@@ -7,6 +7,7 @@ dates: ["2021-09-06"]
 aliases:
   - /case-studies/protonmail-clarifies-its-privacy-policies/
   - /en/case-studies/protonmail-clarifies-its-privacy-policies/
+author: Elsa Trujilo
 ---
 
 On September 6, 2021, ProtonMail <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/510c7d65e4254e1d53221b139d7e25bb2b990510">amended</a> its privacy policies so as to clarify the effects of Swiss laws (where the company is based) on the handling of user data. So, while the company claims to offer a particularly secure email service, it may find itself "forced to share the IP address" of its users with law enforcement in criminal investigations.

--- a/content/memos/qwant-details-data-shared-with-microsoft.fr.md
+++ b/content/memos/qwant-details-data-shared-with-microsoft.fr.md
@@ -5,6 +5,7 @@ service: "Qwant"
 terms_types: ["Privacy Policy"]
 dates: ["2021-11-02"]
 aliases: /fr/etudes-de-cas/qwant-detaille-les-donnees-partagees-avec-microsoft/
+author: Thomas Reboul
 ---
 
 Le 2 novembre 2021, Qwant <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/549e959ef7671a194b9bedba8d12c8031c39b922">précise</a> dans sa politique de vie privée, le type de données qu’elle transmet à son partenaire Microsoft « pour la sécurité et la fiabilité de ses services ». Parmi les données que le service peut partager avec Bing, le moteur de recherche du géant américain, on trouve les mot-clés recherchés, le type et la version du navigateur utilisé, ou encore un identifiant calculé à partir de l’adresse IP et des informations du navigateur.

--- a/content/memos/qwant-details-data-shared-with-microsoft.md
+++ b/content/memos/qwant-details-data-shared-with-microsoft.md
@@ -7,6 +7,7 @@ dates: ["2021-11-02"]
 aliases:
   - /case-studies/qwant-details-data-shared-with-microsoft/
   - /en/case-studies/qwant-details-data-shared-with-microsoft/
+author: Thomas Reboul
 ---
 
 On November 2, 2021, Qwant <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/contrib-versions/commit/549e959ef7671a194b9bedba8d12c8031c39b922">specified</a> in its privacy policy the type of data it passes on to its partner Microsoft "for the security and reliability of its services." Among the data that the service can share with Bing, the search engine of the American giant, are the keywords searched, the type and version of the browser used, or an identifier derived from the IP address and browser information.

--- a/content/memos/terrorists-and-their-content-banned-from-twitter.fr.md
+++ b/content/memos/terrorists-and-their-content-banned-from-twitter.fr.md
@@ -5,6 +5,7 @@ service: "Twitter"
 terms_types: ["Community Guidelines"]
 dates: ["2022-04-20"]
 aliases: /fr/etudes-de-cas/twitter-ajoute-une-interdiction-de-diffusion-des-faits-terroristes/
+author: Mathilde Saliou
 ---
 
 Depuis le 20 avril, Twitter [annonce](https://github.com/OpenTermsArchive/france-elections-versions/commit/4c973b7c1cfa724c3f922adb88be091957a676c1?diff=unified&short_path=97a74cf#diff-97a74cf182c32c5fd04a7f7ad157a172456b1e3ead0535083736fb3a8ce84c38) qu’il supprimera « tous les comptes gérés par des auteurs individuels d'attaques terroristes, extrémistes violentes ou violentes de masse » et qu’il pourra supprimer tous les contenus tiers « diffusant des manifestes ou d'autres contenus réalisés par les auteurs ».

--- a/content/memos/terrorists-and-their-content-banned-from-twitter.md
+++ b/content/memos/terrorists-and-their-content-banned-from-twitter.md
@@ -7,6 +7,7 @@ dates: ["2022-04-20"]
 aliases:
   - /case-studies/terrorists-and-their-content-banned-from-twitter/
   - /en/case-studies/terrorists-and-their-content-banned-from-twitter/
+author: Mathilde Saliou
 ---
 
 Twitter [made clear](https://github.com/OpenTermsArchive/france-elections-versions/commit/4c973b7c1cfa724c3f922adb88be091957a676c1?diff=unified&short_path=97a74cf#diff-97a74cf182c32c5fd04a7f7ad157a172456b1e3ead0535083736fb3a8ce84c38) that it will delete "any accounts maintained by individual perpetrators of terrorist, violent extremist, or mass violent attacks" and that it may delete all third-party content "disseminating manifestos or other content produced by the perpetrators".

--- a/content/memos/twitter-adds-a-tool-to-report-spam-and-impersonation.fr.md
+++ b/content/memos/twitter-adds-a-tool-to-report-spam-and-impersonation.fr.md
@@ -4,6 +4,7 @@ title: Twitter facilite le signalement des spams et usurpation d'identité
 service: Twitter
 terms_types: ["Community Guidelines"]
 dates: ["2022-03-29"]
+author: Mathilde Saliou
 ---
 
 Pour signaler des tweets considérés comme spam ou usurpant l’identité, l’utilisateur devait auparavant aller sur le tweet en question puis utiliser la fonctionnalité « signaler le tweet ». Il pourra [désormais](https://github.com/OpenTermsArchive/france-elections-versions/commit/056ada5513abfade20cd73458e56e41abe2f80cf?short_path=3089779#diff-3089779674bfd306d704d6da138bf9e166d07e8145f5bb30e7998f2fcdf9cdcf) passer par [un formulaire](https://help.twitter.com/fr/forms/authenticity/impersonation) sans avoir besoin de posséder un compte Twitter.

--- a/content/memos/twitter-adds-a-tool-to-report-spam-and-impersonation.md
+++ b/content/memos/twitter-adds-a-tool-to-report-spam-and-impersonation.md
@@ -4,6 +4,7 @@ title: Twitter adds a tool to report spam and impersonation
 service: Twitter
 terms_types: ["Community Guidelines"]
 dates: ["2022-03-29"]
+author: Mathilde Saliou
 ---
 
 To report tweets that are considered spam or impersonation, users previously had to go to the tweet and then use the "report tweet" feature. [Now](https://github.com/OpenTermsArchive/france-elections-versions/commit/056ada5513abfade20cd73458e56e41abe2f80cf?short_path=3089779#diff-3089779674bfd306d704d6da138bf9e166d07e8145f5bb30e7998f2fcdf9cdcf) they can use [a form](https://help.twitter.com/fr/forms/authenticity/impersonation) without having to have a Twitter account.

--- a/content/memos/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.fr.md
+++ b/content/memos/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.fr.md
@@ -5,6 +5,7 @@ service: "Twitter"
 terms_types: ["Copyright Claims Policy"]
 dates: ["2022-04-13"]
 aliases: /fr/etudes-de-cas/twitter-conditionne-les-demandes-de-retrait-du-contenu-a-un-consentement-juridictionnel/
+author: Mathilde Saliou
 ---
 
 Le 13 avril, Twitter <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/7460a0728476c0835c20ef973e113674b450ddc7?diff=split">ajoute</a> une nouvelle condition aux contestations de retrait de contenu enfreignant les droits d’auteur : la signature d'une déclaration de consentement juridictionnel, légèrement différente selon que l’adresse de l’internaute est américaine ou non. Pour une personne française, il faudra donc joindre à ses coordonnées, sa signature, une déclaration de bonne foi et l'identification des contenus retirés ou désactivés la déclaration suivante : « j'accepte la compétence de toute cour de justice dans laquelle Twitter peut se trouver ».

--- a/content/memos/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.md
+++ b/content/memos/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process.md
@@ -7,6 +7,7 @@ dates: ["2022-04-13"]
 aliases:
   - /case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process/
   - /en/case-studies/twitter-adds-form-and-statement-of-jurisdictional-consent-to-its-copyright-claims-process/
+author: Mathilde Saliou
 ---
 
 On April 13, Twitter added a new condition to the issuance of a notice of dispute: it now requests the signature of a declaration of jurisdictional consent, which varies slightly depending on whether the user resides in the USA or not. For a French resident, it will therefore be necessary to attach to their information the statement of jurisdictional consent: "I consent to the jurisdiction of any court in which Twitter may be located."

--- a/content/memos/twitter-bans-duplicated-tweets.fr.md
+++ b/content/memos/twitter-bans-duplicated-tweets.fr.md
@@ -4,6 +4,7 @@ title: "Twitter interdit les tweets dupliqués"
 service: "Twitter"
 terms_types: ["Community Guidelines - Platform Manipulation"]
 dates: ["2022-05-10"]
+author: Mathilde Saliou
 ---
 
 Twitter [ajoute](https://github.com/OpenTermsArchive/france-elections-versions/commit/0bf0a8f85460f936781141bfaf764183867d0685) une interdiction de poster des « Tweets comportant une phrase ou un contenu existant de manière dupliquée, que ce soit individuellement ou de concert avec d'autres comptes ». La modification a été ajoutée aux règles françaises alors que Twitter publiait des explications plus longues, [en anglais](https://help.twitter.com/en/rules-and-policies/copypasta-duplicate-content), sur le renforcement de sa lutte contre les « copypastas ».

--- a/content/memos/twitter-bans-duplicated-tweets.md
+++ b/content/memos/twitter-bans-duplicated-tweets.md
@@ -4,6 +4,7 @@ title: "Twitter bans duplicated tweets"
 service: "Twitter"
 terms_types: ["Community Guidelines - Platform Manipulation"]
 dates: ["2022-05-10"]
+author: Mathilde Saliou
 ---
 
 Twitter [added](https://github.com/OpenTermsArchive/france-elections-versions/commit/0bf0a8f85460f936781141bfaf764183867d0685) a ban on "Tweeting an existing phrase or content in a duplicative manner, whether individually or in concert with other accounts". The change was added as Twitter updated a longer explanation of its reinforced fight against "copypastas", both in the [English](https://help.twitter.com/en/rules-and-policies/copypasta-duplicate-content) and the [French](https://help.twitter.com/fr/rules-and-policies/copypasta-duplicate-content) versions of its Platform integrity and authenticity rules.

--- a/content/memos/twitter-bans-publishing-about-prisoners-of-war.fr.md
+++ b/content/memos/twitter-bans-publishing-about-prisoners-of-war.fr.md
@@ -4,6 +4,7 @@ title: Twitter ajoute une interdiction de publication relative aux prisonniers d
 service: Twitter
 terms_types: ["Community Guidelines - Privacy Violations"]
 dates: ["2022-04-06"]
+author: Mathilde Saliou
 ---
 
 Dans le contexte de la guerre en Ukraine, Twitter vient [d’ajouter](https://github.com/OpenTermsArchive/france-elections-versions/commit/d02a5431f787dcd58dc037497c06beed65c0c897?short_path=9696c1d#diff-9696c1df7dd16cea30f236779e0093c85e13ecc25835f5d9050a24b2f7479140) à ses règles de communauté françaises une interdiction de publier des éléments relatifs à une personne sans obtenir son consentement. Le réseau déclare désormais prohiber « les médias montrant des prisonniers de guerre publiés par des comptes de médias gouvernementaux ou affiliés à un État à compter du 5 avril 2022. » Cela pourrait impacter la couverture du conflit par des médias comme Russia Today ou Sputnik, notoirement liés au gouvernement russe.

--- a/content/memos/twitter-bans-publishing-about-prisoners-of-war.md
+++ b/content/memos/twitter-bans-publishing-about-prisoners-of-war.md
@@ -4,6 +4,7 @@ title: Twitter bans publishing about prisoners of war
 service: Twitter
 terms_types: ["Community Guidelines - Privacy Violations"]
 dates: ["2022-04-06"]
+author: Mathilde Saliou
 ---
 
 Starting April 5, Twitter [will ban](https://github.com/OpenTermsArchive/france-elections-versions/commit/d02a5431f787dcd58dc037497c06beed65c0c897?short_path=9696c1d#diff-9696c1df7dd16cea30f236779e0093c85e13ecc25835f5d9050a24b2f7479140) publishing "media showing prisoners of war published by government or state-affiliated media accounts" as part of their policy preventing content related to a person from being published without their consent.

--- a/content/memos/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.fr.md
+++ b/content/memos/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.fr.md
@@ -5,6 +5,7 @@ service: "Twitter"
 terms_types: ["Copyright Claims Policy"]
 dates: ["2022-04-13"]
 aliases: /fr/etudes-de-cas/twitter-precise-les-conditions-de-suspension-de-compte-et-permet-den-faire-appel/
+author: Mathilde Saliou
 ---
 
 Twitter <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/7460a0728476c0835c20ef973e113674b450ddc7?diff=split#diff-94d9703ecc78b55a64d2e9f016e79c8f6ab5c81939cc42aeef917987a602d94eR136">précise</a> que les suspensions de compte pour infraction aux droits d’auteur ne peuvent avoir lieu qu’en cas « d’infraction répétée » et non plus qu’elles « peuvent varier selon les services ». Plus important, une procédure d’appel est ouverte par le biais d’un <a target="_blank" rel="noopener" href="https://help.twitter.com/forms/general?subtopic=suspended">formulaire dédié</a>.

--- a/content/memos/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.md
+++ b/content/memos/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal.md
@@ -7,6 +7,7 @@ dates: ["2022-04-13"]
 aliases:
   - /case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal/
   - /en/case-studies/twitter-clarifies-its-content-suspensions-rules-and-allows-appeal/
+author: Mathilde Saliou
 ---
 
 Twitter <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/7460a0728476c0835c20ef973e113674b450ddc7?diff=split">clarifies</a> that content suspension for copyright infringement only happens if the violation of its Copyright Policy is “repeated”. Such a measure cannot “vary depending on the type of services” anymore. Furthermore, Twitter introduces an <a target="_blank" rel="noopener" href="https://help.twitter.com/forms/general?subtopic=suspended">appeal form</a>.

--- a/content/memos/twitter-steps-up-control-on-fake-accounts.fr.md
+++ b/content/memos/twitter-steps-up-control-on-fake-accounts.fr.md
@@ -4,6 +4,7 @@ title: Twitter accentue le contrôle des faux comptes
 service: Twitter
 terms_types: ["Community Guidelines"]
 dates: ["2022-03-29"]
+author: Mathilde Saliou
 ---
 
 Dans une modification de ses [Règles communautaires](https://github.com/OpenTermsArchive/france-elections-versions/commit/9e02e8dc2a10ce9d388677c4ba190804bf31390f?short_path=97a74cf#diff-97a74cf182c32c5fd04a7f7ad157a172456b1e3ead0535083736fb3a8ce84c38) du 24 mars 2022, Twitter a modifié la partie concernant l’authenticité des comptes. Le réseau s’attaquait auparavant uniquement à l’« usurpation d’identité », et indique désormais cibler toutes les identités « fallacieuses et trompeuses », ajoutant qu’il interdit d’« utiliser de fausse identité d'une façon qui perturbe l'expérience des autres utilisateurs ». Dans ses règles relatives à la [manipulation de la plateforme](https://github.com/OpenTermsArchive/france-elections-versions/commit/befac4352f27254954ef51acb9c2fa6ae0270bd5), Twitter bascule d’une contrainte sur les « compte et identité » vers les « comptes multiples et coordination », remplaçant la mention de « faux comptes » par l’interdiction de « créer un très grand nombre de comptes » et de « recourir à l'automatisation pour créer des comptes ». Pour autant, la plateforme a [retiré](https://github.com/OpenTermsArchive/france-elections-versions/commit/056ada5513abfade20cd73458e56e41abe2f80cf#diff-3089779674bfd306d704d6da138bf9e166d07e8145f5bb30e7998f2fcdf9cdcfL161) de ses défis antispam la possibilité de demander une pièce d’identité officielle.

--- a/content/memos/twitter-steps-up-control-on-fake-accounts.md
+++ b/content/memos/twitter-steps-up-control-on-fake-accounts.md
@@ -4,6 +4,7 @@ title: Twitter steps up control on fake accounts
 service: Twitter
 terms_types: ["Community Guidelines"]
 dates: ["2022-03-29"]
+author: Mathilde Saliou
 ---
 
 In an [amendment to its Community Rules](https://github.com/OpenTermsArchive/france-elections-versions/commit/9e02e8dc2a10ce9d388677c4ba190804bf31390f?short_path=97a74cf#diff-97a74cf182c32c5fd04a7f7ad157a172456b1e3ead0535083736fb3a8ce84c38), Twitter changed its section regarding account authenticity. The platform previously addressed only "impersonation" while it now targets all "false and misleading" identities, prohibiting "using false identities in a way that disrupts the experience of other users." In its rules on [platform manipulation](https://github.com/OpenTermsArchive/france-elections-versions/commit/befac4352f27254954ef51acb9c2fa6ae0270bd5), Twitter switched from constraining "account and identity" to preventing "multiple accounts and coordination", replacing the mention of "fake accounts" with a ban on "creating a very large number of accounts" and "using automation to create accounts." Surprisingly, the platform however [removed](https://github.com/OpenTermsArchive/france-elections-versions/commit/056ada5513abfade20cd73458e56e41abe2f80cf#diff-3089779674bfd306d704d6da138bf9e166d07e8145f5bb30e7998f2fcdf9cdcfL161) from its anti-spam tools the possibility to ask for an official ID.

--- a/content/memos/unavailability-of-the-french-version-of-instagrams-copyright-policy.fr.md
+++ b/content/memos/unavailability-of-the-french-version-of-instagrams-copyright-policy.fr.md
@@ -4,6 +4,7 @@ title: Les règles communautaires d’Instagram en matière de droits d’auteur
 service: Instagram
 terms_types: ["Community Guidelines - Intellectual Property"]
 dates: ["2022-04-06"]
+author: Mathilde Saliou
 ---
 
 Instagram semble avoir des problèmes dans la publication de ses règles de communauté en français depuis le 5 avril 2022. Selon les tests effectués par Open Terms Archive, certaines parties du texte sont totalement inaccessibles en français (la page « [que se passe-t-il quand je signale une violation des droits d’auteurs](https://github.com/OpenTermsArchive/france-elections-versions/commit/00799bfa25dd930aa68af8dbbfa8ed59cda35b5f) » maintient une version anglaise), ou seulement partiellement traduites (pour la page globale « [droits d’auteurs](https://github.com/OpenTermsArchive/france-elections-versions/commit/21eae014249e946abdc9eb3609b2e3f7c3ac181d?diff=split&short_path=c108c01#diff-c108c013f0b8769389f20259465cb81324e805f4334bcda6931344e16f999441) », l’introduction et les titres sont en anglais, le reste du texte est en français).

--- a/content/memos/unavailability-of-the-french-version-of-instagrams-copyright-policy.md
+++ b/content/memos/unavailability-of-the-french-version-of-instagrams-copyright-policy.md
@@ -4,6 +4,7 @@ title: Unavailability of the French version of Instagram’s copyright policy
 service: Instagram
 terms_types: ["Community Guidelines - Intellectual Property"]
 dates: ["2022-04-06"]
+author: Mathilde Saliou
 ---
 
 Instagram seems to have trouble publishing its community rules on its French website since April 5. According to tests conducted by Open Terms Archive, some parts of the text are completely unavailable in French (the ["What happens when I submit a copyright report to Instagram ?"](https://github.com/OpenTermsArchive/france-elections-versions/commit/00799bfa25dd930aa68af8dbbfa8ed59cda35b5f) page only shows an English version), or only partially translated (in the ["copyright" page](https://github.com/OpenTermsArchive/france-elections-versions/commit/21eae014249e946abdc9eb3609b2e3f7c3ac181d), the introduction and titles are in English, the rest of the text is in French)

--- a/content/memos/youtube-adds-health-data-to-the-information-prohibited-from-being-published.fr.md
+++ b/content/memos/youtube-adds-health-data-to-the-information-prohibited-from-being-published.fr.md
@@ -5,6 +5,7 @@ service: "YouTube"
 terms_types: ["Community Guidelines"]
 dates: ["2022-04-12"]
 aliases: /fr/etudes-de-cas/youtube-interdit-la-publication-des-informations-de-sante-par-un-tiers/
+author: Mathilde Saliou
 ---
 
 Depuis le 12 avril, YouTube <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/9d6c4832b8ff3de62b095b1b29c53d83c7722d27?diff=split&short_path=0222544#">interdit</a> la divulgation d’informations « personnelles » d’une autre personne et non plus seulement des informations « confidentielles ». Notamment, les « dossiers médicaux » font leur apparition parmi les exemples d’informations personnelles.

--- a/content/memos/youtube-adds-health-data-to-the-information-prohibited-from-being-published.md
+++ b/content/memos/youtube-adds-health-data-to-the-information-prohibited-from-being-published.md
@@ -7,6 +7,7 @@ dates: ["2022-04-12"]
 aliases:
   - /case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published/
   - /en/case-studies/youtube-adds-health-data-to-the-information-prohibited-from-being-published/
+author: Mathilde Saliou
 ---
 
 Since April 12, YouTube <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/9d6c4832b8ff3de62b095b1b29c53d83c7722d27?diff=split&short_path=0222544#">forbids</a> the disclosure of another person’s “personal” data, and not only one’s “confidential” data. The harassment section of its French community guidelines now adds “medical records” to the examples of information a user is prohibited from divulging about a third party.

--- a/content/memos/youtube-closes-its-fast-track-content-flagging-program-to-individuals.fr.md
+++ b/content/memos/youtube-closes-its-fast-track-content-flagging-program-to-individuals.fr.md
@@ -5,6 +5,7 @@ service: "YouTube"
 terms_types: ["Community Guidelines"]
 dates: ["2022-04-27"]
 aliases: /fr/etudes-de-cas/youtube-ferme-aux-individus-son-programme-de-signalement-facilite-de-contenu/
+author: Mathilde Saliou
 ---
 
 YouTube <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/31605bd7408cdfe8c6362aa81ffa1d65a81dc2d8#diff-9c397c37c7e78e06148eed3f044d003da8f001e9149d65f3a08bbfdca997d612L103">a modifié</a> la présentation de son programme YouTube Trusted Flagger, qui offre un accès plus direct à la plateforme pour retirer les publications contraires à ses règles. Si celui-ci était auparavant destiné à certaines ONG, « aux autorités administratives et aux utilisateurs qui signalent avec efficacité des contenus qui enfreignent le règlement », il est désormais présenté comme ouvert seulement aux organisations non gouvernementales et aux autorités.

--- a/content/memos/youtube-closes-its-fast-track-content-flagging-program-to-individuals.md
+++ b/content/memos/youtube-closes-its-fast-track-content-flagging-program-to-individuals.md
@@ -7,6 +7,7 @@ dates: ["2022-04-27"]
 aliases:
   - /case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals/
   - /en/case-studies/youtube-closes-its-fast-track-content-flagging-program-to-individuals/
+author: Mathilde Saliou
 ---
 
 YouTube <a target="_blank" rel="noopener" href="https://github.com/OpenTermsArchive/france-elections-versions/commit/31605bd7408cdfe8c6362aa81ffa1d65a81dc2d8#diff-9c397c37c7e78e06148eed3f044d003da8f001e9149d65f3a08bbfdca997d612L103">changed</a> the presentation of its YouTube Trusted Flagger program, which offers more direct access to the platform to remove posts that violate its rules. It was until then intended for some NGOs, government agencies and users who effectively report content that violates the rules. It is now presented as open only to non-governmental organizations and public authorities.

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -118,4 +118,4 @@ pagination:
     current:
       aria_label: Current page, number {{ .currrentPageNumber }}
 memos:
-  author: By <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, a third-party contributor
+  author: By <a href="{{ .profile }}" target="_blank" rel="noopener">{{ .name }}</a>, a third-party contributor

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -109,8 +109,6 @@ stats:
 alias:
   title: You should be redirected quickly
   message: You should be redirected quickly, if not <a href="{{ .permalink }}">click here</a>.
-memos:
-  disclaimer: This analysis is written by an independent contributor and does not necessarily match the understanding of Open Terms Archive.
 pagination:
   nav_aria_label: Pagination Navigation
   previous_page: Previous page

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -117,3 +117,5 @@ pagination:
     aria_label: Page number {{ .currrentPageNumber }}
     current:
       aria_label: Current page, number {{ .currrentPageNumber }}
+memos:
+  author: By <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, a third-party contributor

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -117,3 +117,5 @@ pagination:
     aria_label: Page numéro {{ .currrentPageNumber }}
     current:
       aria_label: Page courante, numéro {{ .currrentPageNumber }}
+memos:
+  author: Par <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, un contributeur tiers

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -118,4 +118,4 @@ pagination:
     current:
       aria_label: Page courante, numéro {{ .currrentPageNumber }}
 memos:
-  author: Par <a href="{{ .profile }}" target="_blank" rel="noopener">{{ .name }}</a>, un contributeur tiers
+  author: Par <a href="{{ .profile }}" target="_blank" rel="noopener">{{ .name }}</a>, un‧e contributeur tiers

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -118,4 +118,4 @@ pagination:
     current:
       aria_label: Page courante, numéro {{ .currrentPageNumber }}
 memos:
-  author: Par <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, un contributeur tiers
+  author: Par <a href="{{ .profile }}" target="_blank" rel="noopener">{{ .name }}</a>, un contributeur tiers

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -109,8 +109,6 @@ stats:
 alias:
   title: Vous devriez être redirigé rapidement
   message: Vous devriez être redirigé rapidement, si toutefois ce n'était pas le cas <a href="{{ .permalink }}">cliquez ici</a>.
-memos:
-  disclaimer: Cette analyse a été rédigée par un contributeur indépendant et ne correspond pas nécessairement à la compréhension d'Open Terms Archive.
 pagination:
   nav_aria_label: Navigation de la pagination
   previous_page: Page précédente

--- a/themes/opentermsarchive/layouts/memos/single.html
+++ b/themes/opentermsarchive/layouts/memos/single.html
@@ -8,7 +8,7 @@
     <div class="container container--109">
       <div class="textcontent">
         <h1 class="mb--s">{{ .Title }}</h1>
-        <h4 class="h4--ultralight mb--3xl">
+        <h4 class="h4--ultralight">
           {{ .Params.service }} ▪
           {{ delimit .Params.terms_types " , " }} ▪
           {{ $formatedDates := slice }}
@@ -18,9 +18,16 @@
           {{ end }}
           {{ delimit $formatedDates " - " }}
         </h4>
+        {{ $contributors := partial "load_contributors.html" . }}
+        {{ with .Params.author }}
+          {{ with index $contributors . }}
+            <div class="author text--light fontstyle--italic">
+              By <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, a third-party contributor
+            </div>
+          {{ end }}
+        {{ end }}
+        <hr class="mt--2xl">
         {{ .Content }}
-        <hr>
-        <p class="text--light fontstyle--italic">{{ i18n "memos.disclaimer" }}</p>
       </div>
     </div>
   </div>

--- a/themes/opentermsarchive/layouts/memos/single.html
+++ b/themes/opentermsarchive/layouts/memos/single.html
@@ -22,7 +22,7 @@
         {{ with .Params.author }}
           {{ with index $contributors . }}
             <div class="author text--light fontstyle--italic">
-              By <a href="{{ .profile }}" target="_blank" rel="nofollow noopener">{{ .name }}</a>, a third-party contributor
+              {{ i18n "memos.author" (dict "profile" .profile "name" .name) | safeHTML }}
             </div>
           {{ end }}
         {{ end }}

--- a/themes/opentermsarchive/layouts/partials/contributor.html
+++ b/themes/opentermsarchive/layouts/partials/contributor.html
@@ -1,0 +1,20 @@
+{{ $thumbnailWidth := default 64 .thumbnailWidth }}
+{{ $thumbnailHeight := default 64 .thumbnailHeight }}
+{{ $showImage := default true .showImage }}
+{{ $showInfo := default false .showInfo }}
+
+<div class="contributor">
+  <a class="contributor__link" href="{{ .contributor.profile }}" target="_blank" rel="nofollow noopener">
+    {{ with $showImage }}
+      {{ $image := default (resources.Get "/images/contributors/placeholder.jpg") (resources.Get (printf "/images/contributors/%s.jpg" ($.contributor.name | urlize))) }}
+      {{ with $.contributor.avatar_url }}
+        {{ $remoteImage := resources.GetRemote . }}
+        {{ if or (eq $remoteImage.Data.ContentType "image/jpeg") (eq $remoteImage.Data.ContentType "image/png") }}
+          {{ $image = $remoteImage }}
+        {{ end }}
+      {{ end }}
+      <img class="contributor__image" src="{{ $image.RelPermalink }}" alt="{{ $.contributor.name }}" width="{{ $thumbnailWidth }}" height="{{ $thumbnailHeight }}">
+    {{ end }}
+    {{ with $showInfo }}<div class="contributor__info">{{ $.contributor.name }}</div>{{ end }}
+  </a>
+</div>

--- a/themes/opentermsarchive/layouts/partials/contributors.html
+++ b/themes/opentermsarchive/layouts/partials/contributors.html
@@ -1,32 +1,10 @@
 {{ $thumbnailWidth := default 64 .thumbnailWidth }}
 {{ $thumbnailHeight := default 64 .thumbnailHeight }}
 
-{{ $contributors := dict }}
-{{ range (resources.Get site.Params.contributors.local_source | unmarshal).contributors }}
-  {{ $contributors = $contributors | merge (dict .name .) }}
-{{ end }}
+{{ $contributors := partial "load_contributors.html" . }}
 
 {{ $allStaffNames := slice }}
 {{ range site.Data.staff }}{{ $allStaffNames = union $allStaffNames . }}{{ end }}
-
-{{ $additionalSources := site.Params.contributors.additional_sources }}
-{{ range site.Data.collections }}
-  {{ $additionalSources = $additionalSources | append (printf "https://raw.githubusercontent.com/OpenTermsArchive/%s-declarations/main/.all-contributorsrc" .id) }}
-{{ end }}
-
-{{ range $additionalSource := $additionalSources }}
-  {{ with resources.GetRemote $additionalSource }}
-    {{ with .Err }}
-      {{ errorf "%s" . }}
-    {{ else }}
-      {{ range (.Content | unmarshal).contributors }}
-        {{ $contributors = $contributors | merge (dict .name .) }}
-      {{ end }}
-    {{ end }}
-  {{ else }}
-    {{ warnf "Unable to get the remote contributors from %q" . }}
-  {{ end }}
-{{ end }}
 
 {{ $filteredContributors := slice }}
 {{ range $contributor := $contributors }}

--- a/themes/opentermsarchive/layouts/partials/contributors.html
+++ b/themes/opentermsarchive/layouts/partials/contributors.html
@@ -44,19 +44,7 @@
 <div class="contributors {{ with .class }}{{ . }}{{ end }} {{ with .showInfo }}contributors--show-infos{{ end }}">
   <div class="contributors__items">
     {{ range $contributor := $filteredContributors }}
-      {{ $image := default (resources.Get "/images/contributors/placeholder.jpg") (resources.Get (printf "/images/contributors/%s.jpg" ($contributor.name | urlize))) }}
-      {{ with $contributor.avatar_url }}
-        {{ $remoteImage := resources.GetRemote . }}
-        {{ if or (eq $remoteImage.Data.ContentType "image/jpeg") (eq $remoteImage.Data.ContentType "image/png") }}
-          {{ $image = $remoteImage }}
-        {{ end }}
-      {{ end }}
-      <div class="contributor">
-        <a class="contributor__link" href="{{ $contributor.profile }}" target="_blank" rel="nofollow noopener">
-          <img class="contributor__image" src="{{ $image.RelPermalink }}" alt="{{ $contributor.name }}" width="{{ $thumbnailWidth }}" height="{{ $thumbnailHeight }}">
-          {{ with $.showInfo }}<div class="contributor__info">{{ $contributor.name }}</div>{{ end }}
-        </a>
-      </div>
+      {{ partial "contributor.html" (dict "contributor" $contributor "thumbnailWidth" $thumbnailWidth "thumbnailHeight" $thumbnailHeight "showInfo" $.showInfo ) }}
     {{ end }}
   </div>
 </div>

--- a/themes/opentermsarchive/layouts/partials/load_contributors.html
+++ b/themes/opentermsarchive/layouts/partials/load_contributors.html
@@ -1,0 +1,25 @@
+{{ $contributors := dict }}
+{{ range (resources.Get site.Params.contributors.local_source | unmarshal).contributors }}
+  {{ $contributors = $contributors | merge (dict .name .) }}
+{{ end }}
+
+{{ $additionalSources := site.Params.contributors.additional_sources }}
+{{ range site.Data.collections }}
+  {{ $additionalSources = $additionalSources | append (printf "https://raw.githubusercontent.com/OpenTermsArchive/%s-declarations/main/.all-contributorsrc" .id) }}
+{{ end }}
+
+{{ range $additionalSource := $additionalSources }}
+  {{ with resources.GetRemote $additionalSource }}
+    {{ with .Err }}
+      {{ errorf "%s" . }}
+    {{ else }}
+      {{ range (.Content | unmarshal).contributors }}
+        {{ $contributors = $contributors | merge (dict .name .) }}
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    {{ warnf "Unable to get the remote contributors from %q" . }}
+  {{ end }}
+{{ end }}
+
+{{ return $contributors }}


### PR DESCRIPTION
That changeset add an author to each memo metadata and displays it on the memo single page.
- I thought it would be a good idea to keep things simple and not display the author's image.
- as I had to create a partial for loading contributors, I also took the opportunity to create a partial for displaying each contributor