### PR TITLE
Add meta description and OpenGraph on alias page

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -107,7 +107,8 @@ stats:
     title: "{{ .number }} collections"
     desc: maintained by various partners
 alias:
-  title: You should be redirected quickly
+  title: Open Terms Archive
+  html_description: Open Terms Archive publicly records every version of the terms of digital services to enable democratic oversight.
   message: You should be redirected quickly, if not <a href="{{ .permalink }}">click here</a>.
 pagination:
   nav_aria_label: Pagination Navigation

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -107,7 +107,8 @@ stats:
     title: "{{ .number }} collections"
     desc: maintenues par divers partenaires
 alias:
-  title: Vous devriez être redirigé rapidement
+  title: Open Terms Archive
+  html_description: Open Terms Archive enregistre publiquement chaque version des conditions d'utilisation des services en ligne pour en permettre le contrôle démocratique.
   message: Vous devriez être redirigé rapidement, si toutefois ce n'était pas le cas <a href="{{ .permalink }}">cliquez ici</a>.
 pagination:
   nav_aria_label: Navigation de la pagination

--- a/themes/opentermsarchive/layouts/alias.html
+++ b/themes/opentermsarchive/layouts/alias.html
@@ -14,6 +14,13 @@
     <meta name="robots" content="noindex">
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+    <meta property="og:title" content="{{ i18n "alias.title" }}">
+    <meta property="og:description" content="{{ i18n "alias.html_description" }}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ .Permalink }}">
+    <meta property="og:image" content="https://opentermsarchive.org/images/opengraph/open-terms-archive.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <script>
       const OTA_BASEURL = {{ (strings.TrimSuffix "/" (absLangURL "")) | jsonify | safeJS }};
       const OTA_PAGES = {{ $pages | jsonify | safeJS }}


### PR DESCRIPTION
As a precaution, for services that consume the homepage without language parameter and not following the redirection, I'm adding the meta description and the OpenGraph data to this alias page.