### PR TITLE
Add collections page

### DIFF
--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -1,6 +1,6 @@
 header:
-  - name: Datasets
-    pageRef: /datasets
+  - name: Collections
+    pageRef: /collections
     weight: 1
   - name: Memos
     pageRef: /memos
@@ -10,7 +10,7 @@ header:
     weight: 3
   - name: Impact
     pageRef: /impact
-    weight: 3
+    weight: 4
   - name: About
     pageRef: /about
     weight: 5
@@ -18,21 +18,24 @@ footer:
   - name: Home
     pageRef: /
     weight: 1
+  - name: Collections
+    pageRef: /Collections
+    weight: 2
   - name: Datasets
     pageRef: /datasets
-    weight: 2
+    weight: 3
   - name: Memos
     pageRef: /memos
-    weight: 3
+    weight: 4
   - name: Documentation
     pageRef: /
-    weight: 4
+    weight: 5
   - name: Impact
     pageRef: /impact
-    weight: 5
+    weight: 6
   - name: About
     pageRef: /about
-    weight: 6
+    weight: 7
 first_subfooter:
   - name: Services status
     url: https://stats.uptimerobot.com/nXvrBcl0wx

--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -1,6 +1,6 @@
 header:
-  - name: Jeux de données
-    pageRef: /datasets
+  - name: Collections
+    pageRef: /collections
     weight: 1
   - name: Mémos
     pageRef: /memos
@@ -10,7 +10,7 @@ header:
     weight: 3
   - name: Impact
     pageRef: /impact
-    weight: 3
+    weight: 4
   - name: A propos
     pageRef: /about
     weight: 5
@@ -18,21 +18,24 @@ footer:
   - name: Accueil
     pageRef: /
     weight: 1
+  - name: Collections
+    pageRef: /collections
+    weight: 2
   - name: Jeux de données
     pageRef: /datasets
-    weight: 2
+    weight: 3
   - name: Mémos
     pageRef: /memos
-    weight: 3
+    weight: 4
   - name: Documentation
     url: https://docs.opentermsarchive.org
-    weight: 4
+    weight: 5
   - name: Impact
     pageRef: /impact
-    weight: 5
+    weight: 6
   - name: À propos
     pageRef: /about
-    weight: 6
+    weight: 7
 first_subfooter:
   - name: État des services
     url: https://stats.uptimerobot.com/nXvrBcl0wx

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -7,7 +7,8 @@ hero:
   subtitle: Open Terms Archive publicly records every version of the terms of digital services to enable democratic oversight.
   link: "[Discover how that makes a difference →]({{< relref path=\"/impact\" >}})"
 collections:
-  title: We establish partnerships to track the terms of many industries, in several languages and jurisdictions
+  title: Featured collections
+  subtitle: We establish partnerships and structure them in collections to track the terms of many industries, in several languages and jurisdictions.
 reuses:
   title: Built with Open Terms Archive
   subtitle: Tools created by the community to shift the power balance from big tech towards end users.

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -7,8 +7,7 @@ hero:
   subtitle: Open Terms Archive publicly records every version of the terms of digital services to enable democratic oversight.
   link: "[Discover how that makes a difference →]({{< relref path=\"/impact\" >}})"
 collections:
-  title: Featured collections
-  subtitle: Collections are created by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. Here are some examples.
+  title: Collections are created by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. Here are some examples.
 reuses:
   title: Built with Open Terms Archive
   subtitle: Tools created by the community to shift the power balance from big tech towards end users.

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -8,7 +8,7 @@ hero:
   link: "[Discover how that makes a difference →]({{< relref path=\"/impact\" >}})"
 collections:
   title: Featured collections
-  subtitle: We establish partnerships and structure them in collections to track the terms of many industries, in several languages and jurisdictions.
+  subtitle: Collections are created by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. Here are some examples.
 reuses:
   title: Built with Open Terms Archive
   subtitle: Tools created by the community to shift the power balance from big tech towards end users.

--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -7,8 +7,7 @@ hero:
   subtitle: Open Terms Archive enregistre publiquement chaque version des conditions d'utilisation des services en ligne pour en permettre le contrôle démocratique.
   link: "[Découvrez comment →]({{< relref path=\"/impact\" >}})"
 collections:
-  title: Collections phares
-  subtitle: Les collections sont créées par des groupes ayant un intérêt commun pour les conditions d'utilisation de services dans des industries, langues et juridictions spécifiques. En voici quelques exemples.
+  title: Les collections sont créées par des groupes ayant un intérêt commun pour les conditions d'utilisation de services dans des industries, langues et juridictions spécifiques. En voici quelques exemples.
 reuses:
   title: Construit avec Open Terms Archive
   subtitle: Des outils créés par la communauté pour rééquilibrer le rapport de force face aux grandes plateformes numériques.

--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -8,7 +8,7 @@ hero:
   link: "[Découvrez comment →]({{< relref path=\"/impact\" >}})"
 collections:
   title: Collections phares
-  subtitle: Nous établissons des partenariats et les structurons en collections pour suivre les conditions d'utilisation de nombreuses industries, dans plusieurs langues et juridictions.
+  subtitle: Les collections sont créées par des groupes ayant un intérêt commun pour les conditions d'utilisation de services dans des industries, langues et juridictions spécifiques. En voici quelques exemples.
 reuses:
   title: Construit avec Open Terms Archive
   subtitle: Des outils créés par la communauté pour rééquilibrer le rapport de force face aux grandes plateformes numériques.

--- a/content/_index.fr.md
+++ b/content/_index.fr.md
@@ -7,7 +7,8 @@ hero:
   subtitle: Open Terms Archive enregistre publiquement chaque version des conditions d'utilisation des services en ligne pour en permettre le contrôle démocratique.
   link: "[Découvrez comment →]({{< relref path=\"/impact\" >}})"
 collections:
-  title: Nous établissons des partenariats pour suivre les conditions d'utilisation de nombreuses industries, dans plusieurs langues et juridictions
+  title: Collections phares
+  subtitle: Nous établissons des partenariats et les structurons en collections pour suivre les conditions d'utilisation de nombreuses industries, dans plusieurs langues et juridictions.
 reuses:
   title: Construit avec Open Terms Archive
   subtitle: Des outils créés par la communauté pour rééquilibrer le rapport de force face aux grandes plateformes numériques.

--- a/content/collections/_index.fr.md
+++ b/content/collections/_index.fr.md
@@ -3,4 +3,6 @@ title: Collections
 html_description: Parcourir les collections Open Terms Archive.
 ---
 
-Les collections sont créées et maintenues par des groupes ayant un intérêt commun pour suivre les conditions d'utilisations de services dans des industries, langues et juridictions spécifiques. Les collections permettent de collaborer tant sur la collecte que l'analyse des données. Pour exploiter les données Open Terms Archive, commencez par identifier la collection qui correspond à vos centres d’intérêts et rejoignez-la, ou créez-en une nouvelle si aucune ne correspond.
+Les collections sont créées et maintenues par des groupes ayant un intérêt commun pour suivre les conditions d'utilisations de services dans des industries, langues et juridictions spécifiques. Elles permettent de collaborer tant sur la collecte que l'analyse des données. 
+
+Pour exploiter les données Open Terms Archive, commencez par identifier la collection qui correspond à vos centres d’intérêts et rejoignez-la, ou créez-en une nouvelle si aucune ne correspond.

--- a/content/collections/_index.fr.md
+++ b/content/collections/_index.fr.md
@@ -3,4 +3,4 @@ title: Collections
 html_description: Parcourir les collections Open Terms Archive.
 ---
 
-Nous établissons des partenariats pour suivre les conditions d'utilisation de nombreuses industries, dans plusieurs langues et juridictions.
+Les collections sont créées et maintenues par des groupes ayant un intérêt commun pour suivre les conditions d'utilisations de services dans des industries, langues et juridictions spécifiques. Les collections permettent de collaborer tant sur la collecte que l'analyse des données. Pour exploiter les données Open Terms Archive, commencez par identifier la collection qui correspond à vos centres d’intérêts et rejoignez-la, ou créez-en une nouvelle si aucune ne correspond.

--- a/content/collections/_index.fr.md
+++ b/content/collections/_index.fr.md
@@ -1,0 +1,6 @@
+---
+title: Collections
+html_description: Parcourir les collections Open Terms Archive.
+---
+
+Nous établissons des partenariats pour suivre les conditions d'utilisation de nombreuses industries, dans plusieurs langues et juridictions.

--- a/content/collections/_index.fr.md
+++ b/content/collections/_index.fr.md
@@ -3,6 +3,6 @@ title: Collections
 html_description: Parcourir les collections Open Terms Archive.
 ---
 
-Les collections sont créées et maintenues par des groupes ayant un intérêt commun pour suivre les conditions d'utilisations de services dans des industries, langues et juridictions spécifiques. Elles permettent de collaborer tant sur la collecte que l'analyse des données. 
+Les collections sont créées et maintenues par des groupes ayant un intérêt commun pour suivre les conditions d'utilisations de services dans des industries, langues et juridictions spécifiques. Elles permettent de collaborer tant sur la collecte que l'analyse des données.
 
 Pour exploiter les données Open Terms Archive, commencez par identifier la collection qui correspond à vos centres d’intérêts et rejoignez-la, ou créez-en une nouvelle si aucune ne correspond.

--- a/content/collections/_index.md
+++ b/content/collections/_index.md
@@ -3,4 +3,4 @@ title: Collections
 html_description: Browse Open Terms Archive collections.
 ---
 
-We establish partnerships to track the terms of many industries, in several languages and jurisdictions.
+Collections are created and maintained by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. They enable collaboration on both data gathering and analysis. To use Open Terms Archive data, start by identifying which collection aligns with your own interests and join it, or create a new one if none matches.

--- a/content/collections/_index.md
+++ b/content/collections/_index.md
@@ -1,0 +1,6 @@
+---
+title: Collections
+html_description: Browse Open Terms Archive collections.
+---
+
+We establish partnerships to track the terms of many industries, in several languages and jurisdictions.

--- a/content/collections/_index.md
+++ b/content/collections/_index.md
@@ -3,4 +3,6 @@ title: Collections
 html_description: Browse Open Terms Archive collections.
 ---
 
-Collections are created and maintained by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. They enable collaboration on both data gathering and analysis. To use Open Terms Archive data, start by identifying which collection aligns with your own interests and join it, or create a new one if none matches.
+Collections are created and maintained by groups of interest to track the terms of services operating in specific industries, languages and jurisdictions. They enable collaboration on both data gathering and analysis.
+
+To use Open Terms Archive data, start by identifying which collection aligns with your own interests and join it, or create a new one if none matches.

--- a/data/collections.json
+++ b/data/collections.json
@@ -46,6 +46,31 @@
     "endpoint": "http://134.102.58.70/collection-api/v1"
   },
   {
+    "name": "France",
+    "id": "france",
+    "languages": ["fr"],
+    "jurisdictions": ["FR"],
+    "industries": {
+      "en": "Largest digital services used in France",
+      "fr": "Principaux services numériques utilisés en France"
+    },
+    "maintainers": [
+      {
+        "name": "UFC Que Choisir",
+        "url": "https://www.quechoisir.org"
+      },
+      {
+        "name": "Ambassadeur français pour le numérique",
+        "url": "https://disinfo.quaidorsay.fr/fr"
+      }
+    ],
+    "stats": {
+      "services": "108",
+      "documents": "216"
+    },
+    "endpoint": "http://198.244.142.9/api/v1"
+  },
+  {
     "name": "P2B Compliance",
     "id": "p2b-compliance",
     "languages": ["*eu"],
@@ -109,31 +134,6 @@
       "fr": "Rencontre en ligne"
     },
     "endpoint": "http://vps-99ae1d89.vps.ovh.net/collection-api/v1"
-  },
-  {
-    "name": "France",
-    "id": "france",
-    "languages": ["fr"],
-    "jurisdictions": ["FR"],
-    "industries": {
-      "en": "Largest digital services used in France",
-      "fr": "Principaux services numériques utilisés en France"
-    },
-    "maintainers": [
-      {
-        "name": "UFC Que Choisir",
-        "url": "https://www.quechoisir.org"
-      },
-      {
-        "name": "Ambassadeur français pour le numérique",
-        "url": "https://disinfo.quaidorsay.fr/fr"
-      }
-    ],
-    "stats": {
-      "services": "108",
-      "documents": "216"
-    },
-    "endpoint": "http://198.244.142.9/api/v1"
   },
   {
     "name": "Contrib",

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -79,7 +79,7 @@ collections:
       one: Jurisdiction
       other: Jurisdictions
   cta:
-    view_all: View all collections
+    view_all: Explore other collections
     browse: Browse terms
     details: View details
     download: Download dataset

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -79,6 +79,7 @@ collections:
       one: Jurisdiction
       other: Jurisdictions
   cta:
+    view_all: View all collections
     browse: Browse terms
     details: View details
     download: Download dataset

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -79,6 +79,7 @@ collections:
       one: Juridiction
       other: Juridictions
   cta:
+    view_all: Voir toutes les collections
     browse: Voir les documents
     details: Voir les détails
     download: Télécharger le jeu de données

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -79,7 +79,7 @@ collections:
       one: Juridiction
       other: Juridictions
   cta:
-    view_all: Voir toutes les collections
+    view_all: Explorer d'autres collections
     browse: Voir les documents
     details: Voir les détails
     download: Télécharger le jeu de données

--- a/themes/opentermsarchive/assets/css/components/container.css
+++ b/themes/opentermsarchive/assets/css/components/container.css
@@ -105,6 +105,10 @@
     }
   }
 
+  &.container--is-white {
+    background-color: var(--colorWhite);
+  }
+
   &.container--has-no-padding-x {
     padding-right: 0;
     padding-left: 0;

--- a/themes/opentermsarchive/assets/css/components/footer.css
+++ b/themes/opentermsarchive/assets/css/components/footer.css
@@ -18,17 +18,17 @@
 
 .footer__menus {
   display: flex;
+  gap: var(--mXL);
   justify-content: space-between;
   width: 100%;
   margin-top: var(--mM);
-  gap: var(--mXL);
 
   & div {
     max-width: 45%;
+
     & ul {
       display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
+      flex-flow: row wrap;
       gap: var(--mS);
 
       & li {
@@ -53,16 +53,18 @@
 
 @media (--tabletLarge) {
   .footer {
-    display:flex;
+    display: flex;
     flex-direction: column;
     align-items: center;
   }
+
   .footer__menus {
     align-items: flex-start;
     justify-content: center;
 
     & div {
       max-width: 100%;
+
       & ul {
         flex-direction: column;
 
@@ -81,8 +83,8 @@
 @media (--mobileExtraLarge) {
   .footer__menus {
     flex-wrap: wrap;
-    justify-content: flex-start;
     gap: var(--mXL);
+    justify-content: flex-start;
 
     & div {
       width: 100%;

--- a/themes/opentermsarchive/assets/css/components/footer.css
+++ b/themes/opentermsarchive/assets/css/components/footer.css
@@ -20,35 +20,25 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
-  margin-top: var(--m2XS);
+  margin-top: var(--mM);
+  gap: var(--mXL);
 
   & div {
-    &:first-child {
-      margin-right: var(--gridGutterWidth);
-    }
-
+    max-width: 45%;
     & ul {
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
+      gap: var(--mS);
 
       & li {
-        margin: 0 var(--mXS);
-
-        &:first-child {
-          margin-left: 0;
-        }
-
-        &:last-child {
-          margin-right: 0;
-        }
-
         & a {
           color: var(--colorBlack600);
         }
       }
 
       & + ul {
-        margin-top: 1rem;
+        margin-top: var(--mS);
       }
     }
   }
@@ -62,32 +52,26 @@
 }
 
 @media (--tabletLarge) {
+  .footer {
+    display:flex;
+    flex-direction: column;
+    align-items: center;
+  }
   .footer__menus {
     align-items: flex-start;
     justify-content: center;
 
     & div {
-      margin: var(--gridGutterWidth) var(--gridColWidth) 0 var(--gridColWidth);
-
+      max-width: 100%;
       & ul {
         flex-direction: column;
 
         & li {
-          margin: var(--mXS);
           text-align: left;
-
-          &:first-child {
-            margin-top: 0;
-            margin-left: var(--mXS);
-          }
-
-          &:last-child {
-            margin-right: var(--mXS);
-          }
         }
 
         & + ul {
-          flex-direction: column;
+          margin-top: var(--mM);
         }
       }
     }
@@ -98,10 +82,10 @@
   .footer__menus {
     flex-wrap: wrap;
     justify-content: flex-start;
+    gap: var(--mXL);
 
     & div {
       width: 100%;
-      margin: var(--gridGutterWidth) 0 0 0;
 
       & ul {
         & li {

--- a/themes/opentermsarchive/layouts/_default/datasets.html
+++ b/themes/opentermsarchive/layouts/_default/datasets.html
@@ -7,6 +7,6 @@
       </div>
     </div>
   </div>
-  {{ partial "collections.html" . }}
+  {{ partial "collections.html" (dict "context" .) }}
   {{ partial "related-datasets.html" . }}
 {{ end }}

--- a/themes/opentermsarchive/layouts/_default/datasets.html
+++ b/themes/opentermsarchive/layouts/_default/datasets.html
@@ -4,9 +4,21 @@
       <div class="textcontent">
         {{ with .Title }}<h1>{{ . }}</h1>{{ end }}
         {{ .Content }}
+        <ul class="mt--xl">
+          {{ $query := where site.RegularPages.ByWeight "Section" "collections" }}
+          {{ range $query }}
+            <li>
+              <a href="https://github.com/openTermsArchive/{{ .Params.id }}-versions/releases/latest" target="_blank" rel="noopener">
+                {{ .Params.name }}
+              </a>
+              <br >
+              {{ with .Params.industries }}{{ index . site.Language.Lang | safeHTML }}{{ end }}
+            </li>
+          {{ end }}
+        </ul>
       </div>
     </div>
   </div>
-  {{ partial "collections.html" (dict "context" .) }}
+
   {{ partial "related-datasets.html" . }}
 {{ end }}

--- a/themes/opentermsarchive/layouts/collections/list.html
+++ b/themes/opentermsarchive/layouts/collections/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  <div class="container container--has-no-padding-y">
+    <div class="container container--98 container--has-no-padding-bottom">
+      <div class="textcontent">
+        {{ with .Title }}<h1>{{ . }}</h1>{{ end }}
+        {{ .Content }}
+      </div>
+    </div>
+  </div>
+  {{ partial "collections.html" (dict "context" . "bgColor" "white") }}
+{{ end }}

--- a/themes/opentermsarchive/layouts/index.html
+++ b/themes/opentermsarchive/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   {{ partial "hero.html" (dict "title" (.Params.hero.title | safeHTML) "subtitle" .Params.hero.subtitle "link" .Params.hero.link "class" "hero--has-no-margin-bottom" "dark" true "anchor" .Params.hero.anchor) }}
   {{ partial "distinctions.html" . }}
-  {{ partial "collections.html" . }}
+  {{ partial "collections.html" (dict "featured" true "context" .) }}
   {{ partial "follow-us.html" . }}
   {{ partial "how-it-works.html" . }}
   {{ partial "reuses.html" . }}

--- a/themes/opentermsarchive/layouts/partials/collection-card.html
+++ b/themes/opentermsarchive/layouts/partials/collection-card.html
@@ -43,7 +43,7 @@
           <i class="icon ml--2xs" data-lucide="search"></i>
         </a>
       </div>
-      <div  class="mt--m">
+      <div class="mt--m">
         <a class="linkicon" href="{{ .Permalink }}">
           {{ i18n "collections.cta.details" }}
           <i class="icon ml--2xs" data-lucide="arrow-right"></i>

--- a/themes/opentermsarchive/layouts/partials/collection-card.html
+++ b/themes/opentermsarchive/layouts/partials/collection-card.html
@@ -1,5 +1,3 @@
-{{ $linksTo := .Scratch.Get "linksTo" }}
-
 <div class="card card--is-white card--center">
   {{ $image := resources.Get (printf "/images/collections/%s.png" (.Params.name | urlize)) }}
   {{ with $image }}
@@ -40,41 +38,17 @@
     </div>
     <div class="mt--xl text--center">
       <div>
-        <a class="button button--secondary" href="{{ .Permalink }}">
+        <a class="button button--secondary" href="https://github.com/openTermsArchive/{{ $.Params.id }}-versions" target="_blank" rel="noopener">
+          {{ i18n "collections.cta.browse" }}
+          <i class="icon ml--2xs" data-lucide="search"></i>
+        </a>
+      </div>
+      <div  class="mt--m">
+        <a class="linkicon" href="{{ .Permalink }}">
           {{ i18n "collections.cta.details" }}
           <i class="icon ml--2xs" data-lucide="arrow-right"></i>
         </a>
       </div>
-      {{ with $linksTo }}
-        {{ if (in . "version") }}
-          <div class="mt--xs">
-            <a class="button button--secondary" href="https://github.com/openTermsArchive/{{ $.Params.id }}-versions" target="_blank" rel="noopener">
-              {{ i18n "collections.cta.browse" }}
-              <i class="icon ml--2xs" data-lucide="search"></i>
-            </a>
-          </div>
-        {{ end }}
-        {{ if (in . "dataset") }}
-          <div class="mt--xs">
-            <a class="button button--secondary" href="https://github.com/openTermsArchive/{{ $.Params.id }}-versions/releases/latest" target="_blank" rel="noopener">
-              {{ i18n "collections.cta.download" }}
-              <i class="icon ml--2xs" data-lucide="download"></i>
-            </a>
-          </div>
-        {{ end }}
-        {{ if (in . "endpoint") }}
-          {{ with $.Params.endpoint }}
-            <div class="mt--s text--center">
-              <a class="linkicon" href="{{ . }}/docs" target="_blank" rel="noopener">
-                <span class="linkicon__content">
-                  {{ i18n "collections.cta.endpoint" }}
-                </span>
-                <i class="icon ml--2xs" data-lucide="wrench"></i>
-              </a>
-            </div>
-          {{ end }}
-        {{ end }}
-      {{ end }}
     </div>
   </div>
   <div class="card__author card__author--is-center">

--- a/themes/opentermsarchive/layouts/partials/collections.html
+++ b/themes/opentermsarchive/layouts/partials/collections.html
@@ -1,7 +1,11 @@
 {{ $linksTo := slice "version" }}
 {{ $bgColor := "gray" }}
 {{ $isDatasetsPage := false }}
-{{ if eq (relref . "/datasets") .Page.RelPermalink }}
+{{ $context := .context }}
+{{ $featured := default false .featured }}
+{{ $query := where site.RegularPages.ByWeight "Section" "collections" }}
+{{ if .featured }}{{ $query = first 3 $query }}{{ end }}
+{{ if eq (relref $context "/datasets") $context.Page.RelPermalink }}
   {{ $linksTo = slice "dataset" "endpoint" }}
   {{ $bgColor = "white" }}
   {{ $isDatasetsPage = true }}
@@ -10,17 +14,17 @@
 <div class="container container--is-{{ $bgColor }} container--wide container--has-no-padding-x container--has-no-padding-top" id="collections">
   <div class="container container--1211 {{ with $isDatasetsPage }}container--has-no-padding-bottom{{ end }}">
     <div class="collections cardlist">
-      {{ with .Params.collections.title }}
+      {{ with $context.Params.collections.title }}
       <div class="cardlist__header cardlist__header--is-center">
         <h2 class="cardlist__title">{{ . }}</h2>
       </div>
       {{ end }}
       <div class="cardlist__items">
-        {{ range where .Site.RegularPages.ByWeight "Section" "collections" }}
+        {{ range $query }}
           {{ .Scratch.Set "linksTo" $linksTo }}
           {{ partial "collection-card.html" . }}
         {{ end }}
-        {{ if not (eq "/datasets/" .Page.RelPermalink) }}
+        {{ if and (not (eq "/datasets/" .Page.RelPermalink)) (not .featured) }}
           {{ partial "new-collection.html" . }}
         {{ end }}
       </div>

--- a/themes/opentermsarchive/layouts/partials/collections.html
+++ b/themes/opentermsarchive/layouts/partials/collections.html
@@ -1,4 +1,3 @@
-{{ $linksTo := slice "version" }}
 {{ $bgColor := default "gray" .bgColor }}
 {{ $isDatasetsPage := false }}
 {{ $context := .context }}
@@ -6,7 +5,6 @@
 {{ $query := where site.RegularPages.ByWeight "Section" "collections" }}
 {{ if .featured }}{{ $query = first 3 $query }}{{ end }}
 {{ if eq (relref $context "/datasets") $context.Page.RelPermalink }}
-  {{ $linksTo = slice "dataset" "endpoint" }}
   {{ $bgColor = "white" }}
   {{ $isDatasetsPage = true }}
 {{ end }}
@@ -21,7 +19,6 @@
       {{ end }}
       <div class="cardlist__items">
         {{ range $query }}
-          {{ .Scratch.Set "linksTo" $linksTo }}
           {{ partial "collection-card.html" . }}
         {{ end }}
         {{ if and (not (eq "/datasets/" .Page.RelPermalink)) (not .featured) }}

--- a/themes/opentermsarchive/layouts/partials/collections.html
+++ b/themes/opentermsarchive/layouts/partials/collections.html
@@ -1,5 +1,5 @@
 {{ $linksTo := slice "version" }}
-{{ $bgColor := "gray" }}
+{{ $bgColor := default "gray" .bgColor }}
 {{ $isDatasetsPage := false }}
 {{ $context := .context }}
 {{ $featured := default false .featured }}
@@ -12,7 +12,7 @@
 {{ end }}
 
 <div class="container container--is-{{ $bgColor }} container--wide container--has-no-padding-x container--has-no-padding-top" id="collections">
-  <div class="container container--1211 {{ with $isDatasetsPage }}container--has-no-padding-bottom{{ end }}">
+  <div class="container container--1211 {{ if or $isDatasetsPage .featured }}container--has-no-padding-bottom{{ end }}">
     <div class="collections cardlist">
       {{ with $context.Params.collections.title }}
       <div class="cardlist__header cardlist__header--is-center">
@@ -29,5 +29,12 @@
         {{ end }}
       </div>
     </div>
+    {{ if $featured }}
+      <div class="container container--1211 container--has-no-padding-bottom text--center">
+        <a href="{{ relref $context "/collections" }}" class="button">
+          {{ i18n "collections.cta.view_all" }}
+        </a>
+      </div>
+    {{ end }}
   </div>
 </div>

--- a/themes/opentermsarchive/layouts/partials/collections.html
+++ b/themes/opentermsarchive/layouts/partials/collections.html
@@ -13,9 +13,12 @@
   <div class="container container--1211 {{ if or $isDatasetsPage .featured }}container--has-no-padding-bottom{{ end }}">
     <div class="collections cardlist">
       {{ with $context.Params.collections.title }}
-      <div class="cardlist__header cardlist__header--is-center">
-        <h2 class="cardlist__title">{{ . }}</h2>
-      </div>
+        <div class="cardlist__header cardlist__header--is-center">
+          <h2 class="cardlist__title">{{ . }}</h2>
+          {{ with $context.Params.collections.subtitle }}
+            <h3 class="cardlist__subtitle h3--light">{{ . }}</h3>
+          {{ end }}
+        </div>
       {{ end }}
       <div class="cardlist__items">
         {{ range $query }}
@@ -30,6 +33,7 @@
       <div class="container container--1211 container--has-no-padding-bottom text--center">
         <a href="{{ relref $context "/collections" }}" class="button">
           {{ i18n "collections.cta.view_all" }}
+          <i class="icon ml--2xs" data-lucide="arrow-right"></i>
         </a>
       </div>
     {{ end }}

--- a/themes/opentermsarchive/layouts/partials/collections.html
+++ b/themes/opentermsarchive/layouts/partials/collections.html
@@ -14,10 +14,7 @@
     <div class="collections cardlist">
       {{ with $context.Params.collections.title }}
         <div class="cardlist__header cardlist__header--is-center">
-          <h2 class="cardlist__title">{{ . }}</h2>
-          {{ with $context.Params.collections.subtitle }}
-            <h3 class="cardlist__subtitle h3--light">{{ . }}</h3>
-          {{ end }}
+          <h3 class="cardlist__subtitle h3--light">{{ . }}</h3>
         </div>
       {{ end }}
       <div class="cardlist__items">

--- a/themes/opentermsarchive/layouts/partials/memo.html
+++ b/themes/opentermsarchive/layouts/partials/memo.html
@@ -2,7 +2,9 @@
 
 <article class="memo{{ with .class }} {{ . }}{{ end }}">
   <header>
-    {{ if eq $template "list" }}<h4 class="memo__title"><a href="{{ .memo.RelPermalink }}">{{ .memo.Title }}</a></h4>{{ end }}
+    {{ if eq $template "list" }}<h4 class="memo__title">
+<a href="{{ .memo.RelPermalink }}">{{ .memo.Title }}</a>
+</h4>{{ end }}
     {{ if eq $template "single" }}<h1 class="memo__title">{{ .memo.Title }}</h1>{{ end }}
 
     {{ if eq $template "list" }}<h6 class="memo__subtitle h6--ultralight">{{ end }}

--- a/themes/opentermsarchive/layouts/partials/related-datasets.html
+++ b/themes/opentermsarchive/layouts/partials/related-datasets.html
@@ -1,4 +1,4 @@
-<div class="container container--has-no-padding-top">
+<div class="container">
   <div class="container container--98 container--has-no-padding-top">
     <div class="textcontent">
       <h2>{{ .Params.related_datasets.title }}</h2>


### PR DESCRIPTION
- Add a collections listing page and make it available in the main menu.
- Highlight 3 collections on the home page.
- Simplify and standardizes the appearance of the datasets page. 

@MattiSG I need help writing the introductory text for the collections page. It's in `/content/collections/_index.md` and `/content/collections/_index.fr.md`