### PR TITLE
Add missing env var to deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,6 +29,8 @@ jobs:
           extended: true # Prevent error building site: POSTCSS: failed to transform, see https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version
 
       - name: Build with Hugo
+        env:
+          UPTIMEROBOT_API_KEY: ${{ secrets.UPTIMEROBOT_API_KEY }}
         run: npm run build
 
       - name: Deploy ./public directory to the remote gh-pages branch


### PR DESCRIPTION
Deployments since #368 do not include uptime data because the UptimeRobot API key is not available in CI. This PR fixes that, as evidenced by the test on [my fork](https://github.com/clementbiron/opentermsarchive.org/actions/runs/12057455085/job/33622186701).