### PR TITLE
Update Hugo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set Hugo up
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.127.0'
+          hugo-version: '0.147.1'
           extended: true # Prevent error building site: POSTCSS: failed to transform, see https://gohugo.io/troubleshooting/faq/#i-get-this-feature-is-not-available-in-your-current-hugo-version
 
       - name: Build with Hugo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set Hugo up
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.127.0'
+          hugo-version: '0.147.1'
           extended: true
       - name: Test broken links
         run: npm run test:links -- --skip '^(?!https?://(www.opentermsarchive.org|netlify.app))'

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Set the `UPTIMEROBOT_API_KEY` environment variable:
 
 #### Hugo
 
-[Install Hugo](https://gohugo.io/getting-started/installing/) in version `0.127.0` edition `extended`.
+[Install Hugo](https://gohugo.io/getting-started/installing/) in version `0.147.1` edition `extended`.
 
 ##### With Homebrew
 
 1. Add Open Terms Archive homebrew tap: `brew tap OpenTermsArchive/homebrew-tap https://github.com/OpenTermsArchive/homebrew-tap`
-2. Install Hugo: `brew install hugo@0.127.0`
+2. Install Hugo: `brew install hugo@0.147.1`
 
 See [Open Terms Archive homebrew tap](https://github.com/OpenTermsArchive/homebrew-tap) for more information.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
 
 [context.deploy-preview.environment]
   HUGO_ENV = "preview"
-  HUGO_VERSION = "0.127.0"
+  HUGO_VERSION = "0.147.1"

--- a/themes/opentermsarchive/layouts/partials/contributor.html
+++ b/themes/opentermsarchive/layouts/partials/contributor.html
@@ -8,9 +8,17 @@
     {{ with $showImage }}
       {{ $image := default (resources.Get "/images/contributors/placeholder.jpg") (resources.Get (printf "/images/contributors/%s.jpg" ($.contributor.name | urlize))) }}
       {{ with $.contributor.avatar_url }}
-        {{ $remoteImage := resources.GetRemote . }}
-        {{ if or (eq $remoteImage.Data.ContentType "image/jpeg") (eq $remoteImage.Data.ContentType "image/png") }}
-          {{ $image = $remoteImage }}
+        {{ with try (resources.GetRemote .) }}
+          {{ with .Err }}
+            {{ errorf "%s" . }}
+          {{ else with .Value }}
+            {{ $remoteImage := . }}
+            {{ if or (eq $remoteImage.Data.ContentType "image/jpeg") (eq $remoteImage.Data.ContentType "image/png") }}
+              {{ $image = $remoteImage }}
+            {{ end }}
+          {{ else }}
+            {{ errorf "Unable to get remote resource %q" . }}
+          {{ end }}
         {{ end }}
       {{ end }}
       <img class="contributor__image" src="{{ $image.RelPermalink }}" alt="{{ $.contributor.name }}" width="{{ $thumbnailWidth }}" height="{{ $thumbnailHeight }}">

--- a/themes/opentermsarchive/layouts/partials/func/getLogo.html
+++ b/themes/opentermsarchive/layouts/partials/func/getLogo.html
@@ -15,26 +15,26 @@
   {{ if in $remoteLogoUrl  "avatars.githubusercontent.com" }}
     {{ $remoteType = "github" }}
   {{ end }}
-  {{ with resources.GetRemote $remoteLogoUrl }}
+  {{ with try (resources.GetRemote $remoteLogoUrl) }}
     {{ with .Err }}
       {{ $errorMessage = .Err }}
-    {{ else }}
+    {{ else with .Value }}
       {{ $resource = . }}
+    {{ else }}
+      {{ $errorMessage = printf "Failed to fetch %s" $remoteLogoUrl }}
     {{ end }}
-  {{ else }}
-    {{ $errorMessage = printf "Failed to fetch %s" $remoteLogoUrl }}
   {{ end }}
 {{ end }}
 
 {{ if not $resource }}
-  {{ with resources.Get $localImagePath }}
+  {{ with try (resources.Get $localImagePath) }}
     {{ with .Err }}
       {{ $errorMessage = .Err }}
-    {{ else }}
+    {{ else with .Value }}
       {{ $resource = . }}
+    {{ else }}
+      {{ $errorMessage = printf "%s\nFailed to fetch %s" $errorMessage $localImagePath }}
     {{ end }}
-  {{ else }}
-    {{ $errorMessage = printf "%s\nFailed to fetch %s" $errorMessage $localImagePath }}
   {{ end }}
 {{ end }}
 

--- a/themes/opentermsarchive/layouts/partials/load_contributors.html
+++ b/themes/opentermsarchive/layouts/partials/load_contributors.html
@@ -10,10 +10,10 @@
 {{ end }}
 
 {{ range $additionalSource := $additionalSources }}
-  {{ with resources.GetRemote $additionalSource }}
+  {{ with try (resources.GetRemote $additionalSource) }}
     {{ with .Err }}
       {{ errorf "%s" . }}
-    {{ else }}
+    {{ else with .Value }}
       {{ $repository := (.Content | unmarshal).projectName }}
       {{ range (.Content | unmarshal).contributors }}
         {{ $contributorName := .name }}
@@ -42,9 +42,9 @@
         {{ $contributors = merge $contributors (dict $contributorName $contributorData) }}
 
       {{ end }}
+    {{ else }}
+      {{ warnf "Unable to get the remote contributors from %q" . }}
     {{ end }}
-  {{ else }}
-    {{ warnf "Unable to get the remote contributors from %q" . }}
   {{ end }}
 {{ end }}
 

--- a/themes/opentermsarchive/layouts/shortcodes/embed.html
+++ b/themes/opentermsarchive/layouts/shortcodes/embed.html
@@ -12,12 +12,14 @@
 */}}
 {{ $ratio := default "56.25%" (.Get "ratio") }}
 
-{{ with resources.GetRemote $src }}
+{{ with try (resources.GetRemote $src) }}
   {{ with .Err }}
     {{ errorf "%s" . }}
-  {{ else }}
+  {{ else with .Value }}
     <div class="embed__wrapper"style="padding-top: {{ $ratio }};">
       <embed src="{{ .RelPermalink }}" type="{{ $type }}" {{ with $title }}title="{{ . }}"{{ end }}>
     </div>
+  {{ else }}
+    {{ errorf "Unable to get remote resource %q" . }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Update Hugo from `0.127.0` to `0.147.1`.

I tried with a fork preview deployment, see the [pull request](https://github.com/clementbiron/opentermsarchive.org/pull/10) and the [preview](https://deploy-preview-10--ota-test.netlify.app/fr/).

I added that version to the Open Terms Archive Homebrew custom tap, see [the commit](https://github.com/OpenTermsArchive/homebrew-tap/commit/2ad50c6e0182084b8f580ae40f2f59037ad30dde).