### PR TITLE
Correct Hugo tap usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set the `UPTIMEROBOT_API_KEY` environment variable:
 
 ##### With Homebrew
 
-1. Add Open Terms Archive homebrew tap: `brew tap OpenTermsArchive/homebrew-tap https://github.com/OpenTermsArchive/homebrew-tap`
+1. Add Open Terms Archive homebrew tap: `brew tap OpenTermsArchive/homebrew-tap`
 2. Install Hugo: `brew install hugo@0.147.1`
 
 See [Open Terms Archive homebrew tap](https://github.com/OpenTermsArchive/homebrew-tap) for more information.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Set the `UPTIMEROBOT_API_KEY` environment variable:
 ##### With Homebrew
 
 1. Add Open Terms Archive homebrew tap: `brew tap OpenTermsArchive/homebrew-tap`
-2. Install Hugo: `brew install hugo@0.147.1`
+2. Remove any previous installation of Hugo: `brew unlink hugo`
+3. Install Hugo: `brew install hugo@0.147.1`
 
 See [Open Terms Archive homebrew tap](https://github.com/OpenTermsArchive/homebrew-tap) for more information.
 


### PR DESCRIPTION
In case of a standard install of Hugo, the tap version won't take priority.