### PR TITLE
Improve English translation of stats page

### DIFF
--- a/content/stats.md
+++ b/content/stats.md
@@ -21,12 +21,12 @@ actors:
       nsm: Number of bills drafted and impact studies facilitated
     - title: Media and press
       role: Influence the reputation of digital services.<br/>Can highlight platform loyalty - or drive users away.
-      case_studies: "In January 2025, [Le Canard Enchaîné](https://www.lecanardenchaine.fr/technologie-sciences/49891-a-bruxelles-la-lutte-anti-musk-reste-dans-les-choux), [Vert.eco](https://vert.eco/articles/musk-zuckerberg-bezos-les-cinq-dernieres-dingueries-des-geants-de-la-tech-qui-montrent-leur-bascule-trumpiste) and other media outlets revealed the extent of Meta’s rollback of hate speech protections—changes that had been detected and [analyzed](https://opentermsarchive.org/fr/memos/meta-retire-des-protections-contre-les-discours-haineux/) by Open Terms Archive just hours after a public statement from the company’s CEO, which focused on other upcoming policy changes."
+      case_studies: "In January 2025, [Le Canard Enchaîné](https://www.lecanardenchaine.fr/technologie-sciences/49891-a-bruxelles-la-lutte-anti-musk-reste-dans-les-choux), [Vert.eco](https://vert.eco/articles/musk-zuckerberg-bezos-les-cinq-dernieres-dingueries-des-geants-de-la-tech-qui-montrent-leur-bascule-trumpiste) and other media outlets revealed the extent of Meta’s rollback of hate speech protections—changes that had been detected and [analysed](https://opentermsarchive.org/fr/memos/meta-retire-des-protections-contre-les-discours-haineux/) by Open Terms Archive just hours after a public statement from the company’s CEO, which focused on other upcoming policy changes."
       icon: newspaper
       nsm: Number of articles published
-    - title: Consumer advocacy organizations
-      role: Help establish case law through complaints and class actions.<br/>Mobilize their base to put pressure on service providers.
-      case_studies: "The French consumer organization [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
+    - title: Consumer protection organisations
+      role: Help establish case law through complaints and class actions.<br/>Mobilise their base to put pressure on service providers.
+      case_studies: "The French consumer protection association [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
       icon: shopping-cart
       nsm: Number of complaints and reports issued
 ---

--- a/content/stats.md
+++ b/content/stats.md
@@ -26,7 +26,7 @@ actors:
       nsm: Number of articles published
     - title: Consumer protection organisations
       role: Help establish case law through complaints and class actions.<br/>Mobilise their base to put pressure on service providers.
-      case_studies: "The French consumer protection association [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
+      case_studies: "French consumer protection association [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
       icon: shopping-cart
       nsm: Number of complaints and reports issued
 ---

--- a/content/stats.md
+++ b/content/stats.md
@@ -1,32 +1,32 @@
 ---
 title: Statistics
-html_description: Total number of documents, services, case studies and analyses in the Open Terms Archive ecosystem
+html_description: Total number of documents, services, case studies and analyses in the Open Terms Archive ecosystem
 hero:
   title: Impact Statistics
-  subtitle: "Digital platforms determine what citizens can say, how their purchases are made, and where their data is processed. These rules are set out in complex and changing documents: terms of service, privacy policies, and community standards, to name a few. <br/><br/>Open Terms Archive makes these rules easier to understand and tracks their changes to ensure that our laws are enforced, our values upheld, and our interests protected in the digital space."
+  subtitle: "Digital platforms determine what citizens can say, how their purchases are made, and where their data is processed. These rules are set out in complex and changing documents: terms of service, privacy policies, and community standards, to name a few. <br/><br/>Open Terms Archive makes these rules easier to understand and tracks their changes to ensure that our laws are enforced, our values upheld, and our interests protected in the digital space."
 layout: stats
 aliases: /stats
 actors:
-  title: Open Terms Archive serves four main types of users with influence over platform governance, pooling and strengthening their ability to drive meaningful change.<br/><br/>Each group is presented below with its typical mode of action, a use case, and its main success indicator - its <span class="fontstyle--italic">North Star Metric</span> <i class="icon icon--size-inherit" data-lucide="sparkles"></i>
+  title: Open Terms Archive serves four main types of users with influence over platform governance, pooling and strengthening their ability to drive meaningful change.<br/><br/>Each group is presented below with its typical mode of action, a use case, and its main success indicator - its <span class="fontstyle--italic">North Star Metric</span> <i class="icon icon--size-inherit" data-lucide="sparkles"></i>
   items:
     - title: Regulators
       role: Control and enforce digital service laws.<br/>Can impose financial sanctions, or even bans on operation.
-      case_studies: "The European Commission uses Open Terms Archive to conduct large-scale [assessments](https://op.europa.eu/en/publication-detail/-/publication/d6a287b5-5116-11ee-9220-01aa75ed71a1/language-en/) of compliance with the world's first horizontal regulation of the digital platform economy, the [P2B Regulation](https://eur-lex.europa.eu/eli/reg/2019/1150/oj), which sets transparency standards for platform-to-business commercial relationships."
+      case_studies: "The European Commission uses Open Terms Archive to conduct large-scale [assessments](https://op.europa.eu/en/publication-detail/-/publication/d6a287b5-5116-11ee-9220-01aa75ed71a1/language-en/) of compliance with the world's first horizontal regulation of the digital platform economy, the [P2B Regulation](https://eur-lex.europa.eu/eli/reg/2019/1150/oj), which sets transparency standards for platform-to-business commercial relationships."
       icon: gavel
       nsm: Number of investigations accelerated
     - title: Legislators
       role: Set the conditions under which services operate in their jurisdictions.<br/>The EU and the US can even shape global practices.
-      case_studies: "US lawmakers introduced the [TLDR Act](https://www.lifewire.com/the-tldr-act-could-help-you-make-sense-of-terms-of-service-agreements-5216643), a bipartisan bill establishing transparency rules for online service terms of use. The feasibility of imposing machine-readable formats was determined prior to parliamentary debates with the expertise and data from Open Terms Archive."
+      case_studies: "US lawmakers introduced the [TLDR Act](https://www.lifewire.com/the-tldr-act-could-help-you-make-sense-of-terms-of-service-agreements-5216643), a bipartisan bill establishing transparency rules for online service terms of use. The feasibility of imposing machine-readable formats was determined prior to parliamentary debates with the expertise and data from Open Terms Archive."
       icon: shield-half
       nsm: Number of bills drafted and impact studies facilitated
     - title: Media and press
       role: Influence the reputation of digital services.<br/>Can highlight platform loyalty - or drive users away.
-      case_studies: "In January 2025, [Le Canard Enchaîné](https://www.lecanardenchaine.fr/technologie-sciences/49891-a-bruxelles-la-lutte-anti-musk-reste-dans-les-choux), [Vert.eco](https://vert.eco/articles/musk-zuckerberg-bezos-les-cinq-dernieres-dingueries-des-geants-de-la-tech-qui-montrent-leur-bascule-trumpiste) and other media outlets revealed the extent of Meta’s rollback of hate speech protections—changes that had been detected and [analysed](https://opentermsarchive.org/fr/memos/meta-retire-des-protections-contre-les-discours-haineux/) by Open Terms Archive just hours after a public statement from the company’s CEO, which focused on other upcoming policy changes."
+      case_studies: "In January 2025, [Le Canard Enchaîné](https://www.lecanardenchaine.fr/technologie-sciences/49891-a-bruxelles-la-lutte-anti-musk-reste-dans-les-choux), [Vert.eco](https://vert.eco/articles/musk-zuckerberg-bezos-les-cinq-dernieres-dingueries-des-geants-de-la-tech-qui-montrent-leur-bascule-trumpiste) and other media outlets revealed the extent of Meta’s rollback of hate speech protections—changes that had been detected and [analysed](https://opentermsarchive.org/fr/memos/meta-retire-des-protections-contre-les-discours-haineux/) by Open Terms Archive just hours after a public statement from the company’s CEO, which focused on other upcoming policy changes."
       icon: newspaper
       nsm: Number of articles published
     - title: Consumer protection organisations
       role: Help establish case law through complaints and class actions.<br/>Mobilise their base to put pressure on service providers.
-      case_studies: "The French consumer protection association [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
+      case_studies: "The French consumer protection association [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
       icon: shopping-cart
       nsm: Number of complaints and reports issued
 ---

--- a/content/stats.md
+++ b/content/stats.md
@@ -26,7 +26,7 @@ actors:
       nsm: Number of articles published
     - title: Consumer advocacy organizations
       role: Help establish case law through complaints and class actions.<br/>Mobilize their base to put pressure on service providers.
-      case_studies: "The French consumer organization [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This led to a call with the platform’s Director of Legal Affairs just 48 hours after the change, and the clause was reinstated in less than five days."
+      case_studies: "The French consumer organization [UFC-Que Choisir](https://www.quechoisir.org/) used Open Terms Archive to detect the removal of a mandatory clause from the general terms and conditions of a major online service. This enabled their Director of Legal Affairs to contact the platform just 48 hours after the change, leading to the clause being reinstated under five days."
       icon: shopping-cart
       nsm: Number of complaints and reports issued
 ---

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -127,7 +127,7 @@ impact:
   reminder: Open Terms Archive publicly records the terms of services of online services in different languages and countries several times a day, increasing their readability and highlighting their changes. It is designed as a tool to steer platform governance towards increased accountability, improved legislation and stronger regulatory compliance.
   link: Read more on our impact model.
 stats:
-  title: The public deployment of Open Terms Archive is tracked by several metrics. In addition to this decentralized and federated ecosystem, private collections dedicated to targeted investigations can exist.
+  title: The public deployment of Open Terms Archive is tracked by several metrics. In addition to this decentralized and federated ecosystem, private collections dedicated to targeted investigations are also deployed.
   services:
     title: "{{ with .number }}{{ . }} {{ end }}targeted services"
     desc: spread across multiple industries, languages and jurisdictions

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -133,7 +133,7 @@ impact:
   reminder: Open Terms Archive enregistre publiquement les conditions d'utilisation des services en ligne dans différentes langues et différents pays plusieurs fois par jour, en améliorant leur lisibilité et en mettant en évidence leurs modifications. Il est conçue comme un outil permettant d'orienter la gouvernance des plateformes vers une plus grande responsabilité, une meilleure législation et une plus grande conformité réglementaire.
   link: En savoir plus sur notre modèle d'impact.
 stats:
-  title: Le déploiement public d’Open Terms Archive est suivi par plusieurs métriques. En plus de cet écosystème décentralisé et fédéré, des collections privées dédiées par exemple à des enquêtes ciblées peuvent exister.
+  title: Le déploiement public d’Open Terms Archive est suivi par plusieurs métriques. En plus de cet écosystème décentralisé et fédéré, des collections privées dédiées par exemple à des enquêtes ciblées sont également déployées.
   services:
     title: "{{ with .number }}{{ . }} {{ end }}services ciblés"
     desc: répartis sur plusieurs industries, langues et juridictions

--- a/themes/opentermsarchive/assets/js/charts/memos.js
+++ b/themes/opentermsarchive/assets/js/charts/memos.js
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
             title(context) {
               const date = new Date(context[0].raw.x);
 
-              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });  // use user's locale, see https://stackoverflow.com/a/31873738
+              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }); // use user's locale, see https://stackoverflow.com/a/31873738
             },
             label(context) {
               const { dataset } = context;

--- a/themes/opentermsarchive/assets/js/charts/memos.js
+++ b/themes/opentermsarchive/assets/js/charts/memos.js
@@ -5,11 +5,8 @@ import Annotation from 'chartjs-plugin-annotation';
 
 Chart.register(Annotation);
 
-const languages = {
-  en: 'Anglais',
-  fr: 'Français',
-  de: 'Allemand',
-};
+const languageLocaliser = new Intl.DisplayNames(undefined, { type: 'language' });
+
 const dataMemos = { months: [ '2020-06', '2020-07', '2021-09', '2021-11', '2022-02', '2022-03', '2022-04', '2022-05', '2022-06', '2023-10', '2023-11', '2023-12', '2024-01', '2024-03', '2024-05', '2024-09', '2025-01', '2025-02', '2025-03', '2025-05' ], languages: [ 'en', 'fr', 'de' ], languagesByDate: [ 'de', 'fr', 'en' ], counts: { fr: [ 1, 2, 3, 5, 9, 13, 21, 24, 28, 28, 28, 28, 28, 28, 28, 29, 30, 31, 31, 32 ], en: [ 1, 2, 3, 5, 9, 13, 21, 24, 28, 29, 33, 37, 40, 41, 43, 44, 46, 47, 48, 49 ], de: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2 ] } };
 
 const colors = {
@@ -31,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
     gradient.addColorStop(1, color.replace('rgb', 'rgba').replace(')', ', 0.05)'));
 
     return {
-      label: languages[lang],
+      label: languageLocaliser.of(lang),
       data: dataMemos.months.map((month, i) => ({
         x: new Date(month),
         y: dataMemos.counts[lang][i],
@@ -102,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
             title(context) {
               const date = new Date(context[0].raw.x);
 
-              return date.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });  // use user's locale, see https://stackoverflow.com/a/31873738
             },
             label(context) {
               const { dataset } = context;

--- a/themes/opentermsarchive/assets/js/charts/services.js
+++ b/themes/opentermsarchive/assets/js/charts/services.js
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
               const total = context[0].raw.y;
 
               return [
-                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),  // use user's locale, see https://stackoverflow.com/a/31873738
+                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }), // use user's locale, see https://stackoverflow.com/a/31873738
                 `${total} services`,
               ];
             },

--- a/themes/opentermsarchive/assets/js/charts/services.js
+++ b/themes/opentermsarchive/assets/js/charts/services.js
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
               const total = context[0].raw.y;
 
               return [
-                date.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' }),
+                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),  // use user's locale, see https://stackoverflow.com/a/31873738
                 `${total} services`,
               ];
             },

--- a/themes/opentermsarchive/assets/js/charts/terms.js
+++ b/themes/opentermsarchive/assets/js/charts/terms.js
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
               const total = context[0].raw.y;
 
               return [
-                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),  // use user's locale, see https://stackoverflow.com/a/31873738
+                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }), // use user's locale, see https://stackoverflow.com/a/31873738
                 `${total} terms`,
               ];
             },

--- a/themes/opentermsarchive/assets/js/charts/terms.js
+++ b/themes/opentermsarchive/assets/js/charts/terms.js
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
               const total = context[0].raw.y;
 
               return [
-                date.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' }),
+                date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),  // use user's locale, see https://stackoverflow.com/a/31873738
                 `${total} terms`,
               ];
             },

--- a/themes/opentermsarchive/assets/js/charts/versions.js
+++ b/themes/opentermsarchive/assets/js/charts/versions.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
             title(context) {
               const date = new Date(context[0].raw.x);
 
-              return date.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });  // use user's locale, see https://stackoverflow.com/a/31873738
             },
             label(context) {
               return `${context.raw.y} changements enregistrés`;

--- a/themes/opentermsarchive/assets/js/charts/versions.js
+++ b/themes/opentermsarchive/assets/js/charts/versions.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
             title(context) {
               const date = new Date(context[0].raw.x);
 
-              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });  // use user's locale, see https://stackoverflow.com/a/31873738
+              return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }); // use user's locale, see https://stackoverflow.com/a/31873738
             },
             label(context) {
               return `${context.raw.y} changements enregistrés`;


### PR DESCRIPTION
- Minor improvements to English translation.
- Prefer British English over US English.
- Enable localisation of most charts (based on browser locale rather than site-defined locale, this could be improved, I will open a separate issue for best implementation).